### PR TITLE
v0.4.0: publishing readiness + new features

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write  # Required for trusted publishing (OIDC)
+  contents: read
+
+jobs:
+  test:
+    name: Test before publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -q -m "not integration" --tb=short
+
+      - name: Lint
+        run: uv run ruff check src/ tests/ --select F,B,E9
+
+  publish:
+    name: Build & publish
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Build
+        run: uv build
+
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package version $PKG"
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.3.0"
+version = "0.4.0"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }
@@ -117,10 +117,10 @@ dev = [
 agnoclaw = "agnoclaw.cli.main:cli"
 
 [project.urls]
-Homepage = "https://github.com/agnoclaw/agnoclaw"
-Documentation = "https://github.com/agnoclaw/agnoclaw#readme"
-Repository = "https://github.com/agnoclaw/agnoclaw"
-Issues = "https://github.com/agnoclaw/agnoclaw/issues"
+Homepage = "https://github.com/yogin16/agnoclaw"
+Documentation = "https://github.com/yogin16/agnoclaw#readme"
+Repository = "https://github.com/yogin16/agnoclaw"
+Issues = "https://github.com/yogin16/agnoclaw/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agnoclaw"]

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -65,4 +65,4 @@ __all__ = [
     "Workspace",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -57,8 +57,9 @@ import asyncio
 import inspect
 import logging
 import warnings
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from pathlib import Path
-from typing import Any, AsyncIterator, Iterator, Optional, Union
+from typing import Any
 from uuid import uuid4
 
 from agno.agent import Agent
@@ -76,6 +77,9 @@ from .runtime import (
     ExecutionContext,
     HarnessError,
     NullEventSink,
+    PermissionApprover,
+    PermissionController,
+    PermissionMode,
     PolicyAction,
     PolicyDecision,
     PolicyEngine,
@@ -84,16 +88,13 @@ from .runtime import (
     PromptEnvelope,
     RunInput,
     RunResultEnvelope,
+    RuntimeGuardrails,
     SkillLoadRequest,
     ToolCallRequest,
     ToolCallResult,
-    PermissionApprover,
-    PermissionController,
-    PermissionMode,
-    normalize_permission_mode,
-    RuntimeGuardrails,
     apply_redactions,
     build_event,
+    normalize_permission_mode,
 )
 from .skills.registry import SkillRegistry
 from .tools import get_default_tools
@@ -154,7 +155,7 @@ _KNOWN_PROVIDERS: set[str] = {
 }
 
 
-def _resolve_model(model: Optional[str], provider: Optional[str], config: HarnessConfig) -> str:
+def _resolve_model(model: str | None, provider: str | None, config: HarnessConfig) -> str:
     """
     Return an Agno-compatible 'provider:model_id' string.
 
@@ -261,57 +262,64 @@ class AgentHarness:
 
     def __init__(
         self,
-        model: Optional[str] = None,
+        model: str | None = None,
         *,
-        provider: Optional[str] = None,
-        session_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        workspace_dir: Optional[str | Path] = None,
-        tools: Optional[list] = None,
-        instructions: Optional[str] = None,
-        config: Optional[HarnessConfig] = None,
+        provider: str | None = None,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        workspace_dir: str | Path | None = None,
+        tools: list | None = None,
+        instructions: str | None = None,
+        config: HarnessConfig | None = None,
         name: str = "agnoclaw",
-        agent_id: Optional[str] = None,
+        agent_id: str | None = None,
         debug: bool = False,
         # Subagents
-        subagents: Optional[dict] = None,
+        subagents: dict | None = None,
         # Memory options
         enable_user_memory: bool = False,
-        enable_learning: Optional[bool] = None,
-        learning_mode: Optional[str] = None,
-        learning_namespace: Optional[str] = None,
+        enable_learning: bool | None = None,
+        learning_mode: str | None = None,
+        learning_namespace: str | None = None,
         # Context management
-        enable_compression: Optional[bool] = None,
-        compress_token_limit: Optional[int] = None,
-        enable_session_summary: Optional[bool] = None,
-        num_history_runs: Optional[int] = None,
-        num_history_messages: Optional[int] = None,
-        max_tool_calls_from_history: Optional[int] = None,
-        max_context_tokens: Optional[int] = None,
+        enable_compression: bool | None = None,
+        compress_token_limit: int | None = None,
+        enable_session_summary: bool | None = None,
+        num_history_runs: int | None = None,
+        num_history_messages: int | None = None,
+        max_tool_calls_from_history: int | None = None,
+        max_context_tokens: int | None = None,
         # v0.2 runtime contracts
-        event_sink: Optional[EventSink] = None,
-        event_sink_mode: Optional[str] = None,
-        policy_engine: Optional[PolicyEngine] = None,
-        policy_fail_open: Optional[bool] = None,
-        permission_mode: Optional[str] = None,
-        permission_approver: Optional[PermissionApprover] = None,
-        permission_require_approver: Optional[bool] = None,
-        permission_preapproved_tools: Optional[list[str] | tuple[str, ...]] = None,
-        permission_preapproved_categories: Optional[list[str] | tuple[str, ...]] = None,
-        pre_run_hooks: Optional[list[PreRunHook]] = None,
-        post_run_hooks: Optional[list[PostRunHook]] = None,
-        tenant_id: Optional[str] = None,
-        org_id: Optional[str] = None,
-        team_id: Optional[str] = None,
-        roles: Optional[list[str] | tuple[str, ...]] = None,
-        scopes: Optional[list[str] | tuple[str, ...]] = None,
-        request_id: Optional[str] = None,
-        trace_id: Optional[str] = None,
-        context_metadata: Optional[dict[str, Any]] = None,
+        event_sink: EventSink | None = None,
+        event_sink_mode: str | None = None,
+        policy_engine: PolicyEngine | None = None,
+        policy_fail_open: bool | None = None,
+        permission_mode: str | None = None,
+        permission_approver: PermissionApprover | None = None,
+        permission_require_approver: bool | None = None,
+        permission_preapproved_tools: list[str] | tuple[str, ...] | None = None,
+        permission_preapproved_categories: list[str] | tuple[str, ...] | None = None,
+        pre_run_hooks: list[PreRunHook] | None = None,
+        post_run_hooks: list[PostRunHook] | None = None,
+        tenant_id: str | None = None,
+        org_id: str | None = None,
+        team_id: str | None = None,
+        roles: list[str] | tuple[str, ...] | None = None,
+        scopes: list[str] | tuple[str, ...] | None = None,
+        request_id: str | None = None,
+        trace_id: str | None = None,
+        context_metadata: dict[str, Any] | None = None,
+        # Skills directories — list of (path, trust_level) tuples
+        skills_dirs: list[tuple[str | Path, str]] | None = None,
+        # Session lifecycle callbacks
+        on_compaction: Callable[[str], Awaitable[None]] | None = None,
+        on_session_end: Callable[[str], Awaitable[None]] | None = None,
+        # Event enrichment — merged into every HarnessEvent's metadata
+        session_metadata: dict[str, Any] | None = None,
         # Legacy compat — use model + provider instead
-        model_id: Optional[str] = None,
-        extra_tools: Optional[list] = None,
-        extra_instructions: Optional[str] = None,
+        model_id: str | None = None,
+        extra_tools: list | None = None,
+        extra_instructions: str | None = None,
     ):
         self.config = config or get_config()
         self.name = name
@@ -325,6 +333,9 @@ class AgentHarness:
         self._request_id = request_id
         self._trace_id = trace_id
         self._context_metadata = dict(context_metadata or {})
+        self._on_compaction = on_compaction
+        self._on_session_end = on_session_end
+        self._session_metadata = dict(session_metadata or {})
 
         # Runtime extension contracts
         self._event_sink: EventSink = event_sink or NullEventSink()
@@ -413,6 +424,9 @@ class AgentHarness:
 
         # Skills registry
         self.skills = SkillRegistry(self.workspace.skills_dir())
+        if skills_dirs:
+            for path, trust in skills_dirs:
+                self.skills.add_directory(path, trust=trust)
 
         # System prompt builder
         self._prompt_builder = SystemPromptBuilder(self.workspace.path)
@@ -537,8 +551,8 @@ class AgentHarness:
     def _build_system_prompt(
         self,
         *,
-        skill_content: Optional[str] = None,
-        session_id: Optional[str] = None,
+        skill_content: str | None = None,
+        session_id: str | None = None,
     ) -> str:
         """Build the canonical system prompt for this harness instance."""
         include_learning = self._include_learning and not self._plan_mode
@@ -569,8 +583,8 @@ class AgentHarness:
     def _set_system_prompt(
         self,
         *,
-        skill_content: Optional[str] = None,
-        session_id: Optional[str] = None,
+        skill_content: str | None = None,
+        session_id: str | None = None,
     ) -> None:
         """Update the underlying agent's system prompt."""
         self._agent.system_message = self._build_system_prompt(
@@ -607,7 +621,7 @@ class AgentHarness:
 
         return f"[error] Command-dispatch tool '{tool_name}' not found in registered tools."
 
-    def set_event_sink(self, sink: EventSink, mode: Optional[str] = None) -> None:
+    def set_event_sink(self, sink: EventSink, mode: str | None = None) -> None:
         """Swap event sink at runtime."""
         self._event_sink = sink
         if mode is not None:
@@ -953,7 +967,7 @@ class AgentHarness:
         except HarnessError as exc:
             self._raise_agent_run_exception(exc)
 
-    def _active_session_id(self, override: Optional[str]) -> Optional[str]:
+    def _active_session_id(self, override: str | None) -> str | None:
         if override is not None:
             return override
         return self.session_id or getattr(self._agent, "session_id", None)
@@ -961,9 +975,9 @@ class AgentHarness:
     def _build_execution_context(
         self,
         *,
-        user_id: Optional[str],
-        session_id: Optional[str],
-        metadata: Optional[dict[str, Any]] = None,
+        user_id: str | None,
+        session_id: str | None,
+        metadata: dict[str, Any] | None = None,
     ) -> ExecutionContext:
         merged_metadata = dict(self._context_metadata)
         merged_metadata.setdefault("permission_mode", self.permission_mode)
@@ -989,13 +1003,14 @@ class AgentHarness:
         event_type: str,
         run_id: str,
         context: ExecutionContext,
-        payload: Optional[dict[str, Any]] = None,
+        payload: dict[str, Any] | None = None,
     ) -> None:
+        merged_payload = {**self._session_metadata, **(payload or {})}
         event = build_event(
             event_type=event_type,
             run_id=run_id,
             context=context,
-            payload=payload,
+            payload=merged_payload,
         )
         try:
             maybe_awaitable = self._event_sink.emit(event)
@@ -1043,13 +1058,14 @@ class AgentHarness:
         event_type: str,
         run_id: str,
         context: ExecutionContext,
-        payload: Optional[dict[str, Any]] = None,
+        payload: dict[str, Any] | None = None,
     ) -> None:
+        merged_payload = {**self._session_metadata, **(payload or {})}
         event = build_event(
             event_type=event_type,
             run_id=run_id,
             context=context,
-            payload=payload,
+            payload=merged_payload,
         )
         try:
             maybe_awaitable = self._event_sink.emit(event)
@@ -1394,13 +1410,14 @@ class AgentHarness:
         *,
         stream: bool = False,
         stream_events: bool = False,
-        skill: Optional[str] = None,
-        session_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        context: Optional[ExecutionContext] = None,
-        metadata: Optional[dict[str, Any]] = None,
+        skill: str | None = None,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        context: ExecutionContext | None = None,
+        metadata: dict[str, Any] | None = None,
+        output_schema: type | None = None,
         **kwargs,
-    ) -> Union[RunOutput, Iterator[RunOutputEvent]]:
+    ) -> RunOutput | Iterator[RunOutputEvent]:
         """Run the agent on a message."""
         self._check_context_budget()
 
@@ -1451,7 +1468,7 @@ class AgentHarness:
             if before_run_decision.action == PolicyAction.ALLOW_WITH_REDACTION:
                 run_input.message = apply_redactions(run_input.message, before_run_decision.redactions)
 
-            skill_content: Optional[str] = None
+            skill_content: str | None = None
             if run_input.skill:
                 self._emit_event_sync(
                     event_type="skill.load.started",
@@ -1564,6 +1581,8 @@ class AgentHarness:
             call_kwargs = dict(kwargs)
             extra_metadata = call_kwargs.pop("metadata", None)
             call_kwargs.pop("run_id", None)
+            if output_schema is not None:
+                call_kwargs["output_schema"] = output_schema
             agent_metadata = self._build_agent_run_metadata(
                 context=ctx,
                 run_input=run_input,
@@ -1701,13 +1720,14 @@ class AgentHarness:
         *,
         stream: bool = False,
         stream_events: bool = False,
-        skill: Optional[str] = None,
-        session_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        context: Optional[ExecutionContext] = None,
-        metadata: Optional[dict[str, Any]] = None,
+        skill: str | None = None,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        context: ExecutionContext | None = None,
+        metadata: dict[str, Any] | None = None,
+        output_schema: type | None = None,
         **kwargs,
-    ) -> Union[RunOutput, AsyncIterator[RunOutputEvent]]:
+    ) -> RunOutput | AsyncIterator[RunOutputEvent]:
         """Async version of run()."""
         self._check_context_budget()
 
@@ -1758,7 +1778,7 @@ class AgentHarness:
             if before_run_decision.action == PolicyAction.ALLOW_WITH_REDACTION:
                 run_input.message = apply_redactions(run_input.message, before_run_decision.redactions)
 
-            skill_content: Optional[str] = None
+            skill_content: str | None = None
             if run_input.skill:
                 await self._emit_event_async(
                     event_type="skill.load.started",
@@ -1830,6 +1850,8 @@ class AgentHarness:
             call_kwargs = dict(kwargs)
             extra_metadata = call_kwargs.pop("metadata", None)
             call_kwargs.pop("run_id", None)
+            if output_schema is not None:
+                call_kwargs["output_schema"] = output_schema
             agent_metadata = self._build_agent_run_metadata(
                 context=ctx,
                 run_input=run_input,
@@ -1968,7 +1990,7 @@ class AgentHarness:
                 retryable=True,
             ) from exc
 
-    def print_response(self, message: str, *, stream: bool = True, skill: Optional[str] = None, **kwargs) -> None:
+    def print_response(self, message: str, *, stream: bool = True, skill: str | None = None, **kwargs) -> None:
         """
         Run the agent through the full runtime pipeline and pretty-print the response.
 
@@ -2030,7 +2052,7 @@ class AgentHarness:
         active_session = self.session_id or getattr(self._agent, "session_id", "")
         return self._agent.get_chat_history(active_session or "")
 
-    def clear_session_context(self, new_session_id: Optional[str] = None) -> str:
+    def clear_session_context(self, new_session_id: str | None = None) -> str:
         """
         Switch to a fresh session ID so subsequent turns start with empty history.
 
@@ -2129,6 +2151,9 @@ class AgentHarness:
         important context to MEMORY.md. Then generates a session summary to
         preserve continuity. Call this when the context window is getting full.
 
+        Fires on_compaction callback (if set) with the summary text so the
+        platform can persist it externally (e.g. to a database).
+
         This is a manual escape hatch — Agno v2.5.x does not auto-compact.
         """
         # Step 1: Ask the agent to write important facts to memory
@@ -2146,10 +2171,54 @@ class AgentHarness:
         )
 
         # Step 2: Generate and persist a session summary
+        summary: str | None = None
         if self._agent.session_summary_manager:
             session = self._agent.get_session(self.session_id)
             if session:
-                self._agent.session_summary_manager.create_session_summary(session)
+                summary = self._agent.session_summary_manager.create_session_summary(session)
+
+        # Step 3: Fire compaction callback so platform can persist the summary
+        if self._on_compaction and summary:
+            await self._on_compaction(summary)
+
+    async def end_session(self, generate_summary: bool = True) -> str | None:
+        """
+        End the current session.
+
+        Optionally generates a conversation summary via a lightweight LLM call,
+        fires the on_session_end callback so the platform can persist it, and
+        returns the summary text.
+        """
+        summary = None
+        if generate_summary:
+            summary = await self._generate_session_summary()
+        if self._on_session_end and summary:
+            await self._on_session_end(summary)
+        return summary
+
+    async def _generate_session_summary(self) -> str | None:
+        """Generate a short summary of the current session via a cheap LLM call."""
+        messages = self.get_chat_history()
+        if not messages:
+            return None
+
+        # Take the last N messages to keep the summary call cheap
+        recent = messages[-20:]
+        history_text = "\n".join(
+            f"{getattr(m, 'role', 'unknown')}: {getattr(m, 'content', str(m))}"
+            for m in recent
+            if getattr(m, "content", None)
+        )
+        if not history_text:
+            return None
+
+        prompt = (
+            "Summarize this conversation in 3-5 bullets focusing on "
+            "decisions made and artifacts produced. Be concise.\n\n"
+            f"{history_text}"
+        )
+        result = await self.arun(prompt, session_id=self.session_id)
+        return str(getattr(result, "content", result) or "")
 
     @property
     def underlying_agent(self) -> Agent:

--- a/tests/test_runtime_contracts.py
+++ b/tests/test_runtime_contracts.py
@@ -438,3 +438,169 @@ def test_guardrails_apply_to_bash_start_network_calls(tmp_path):
     inner = exc.value.args[0]
     assert isinstance(inner, HarnessError)
     assert inner.code == "GUARDRAIL_DENIED"
+
+
+# ── session_metadata on events ────────────────────────────────────────
+
+
+def test_session_metadata_merged_into_events(tmp_path):
+    """session_metadata dict is merged into every emitted event's payload."""
+    sink = InMemoryEventSink()
+    harness, mock_agent = _make_harness(
+        tmp_path,
+        event_sink=sink,
+        session_metadata={"deal_id": "acme-123", "fund_id": "fund-iii"},
+    )
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run("hello")
+
+    for event in sink.events:
+        assert event.payload.get("deal_id") == "acme-123", (
+            f"Event {event.event_type} missing deal_id"
+        )
+        assert event.payload.get("fund_id") == "fund-iii", (
+            f"Event {event.event_type} missing fund_id"
+        )
+
+
+def test_session_metadata_does_not_clobber_event_payload(tmp_path):
+    """Event-specific payload keys take precedence over session_metadata."""
+    sink = InMemoryEventSink()
+    harness, mock_agent = _make_harness(
+        tmp_path,
+        event_sink=sink,
+        session_metadata={"stream": "should-be-overridden"},
+    )
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run("hello")
+
+    started = [e for e in sink.events if e.event_type == "run.started"][0]
+    # The run.started payload sets stream=False, which should win
+    assert started.payload["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_session_metadata_on_async_events(tmp_path):
+    """session_metadata works in the async path too."""
+    sink = InMemoryEventSink()
+    harness, mock_agent = _make_harness(
+        tmp_path,
+        event_sink=sink,
+        session_metadata={"tenant": "t-1"},
+    )
+    mock_agent.arun = AsyncMock(return_value=SimpleNamespace(content="ok"))
+
+    await harness.arun("hello")
+
+    for event in sink.events:
+        assert event.payload.get("tenant") == "t-1", (
+            f"Async event {event.event_type} missing tenant"
+        )
+
+
+# ── on_compaction callback ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_compaction_callback_fires(tmp_path):
+    """on_compaction is called with the summary after compact_session()."""
+    received: list[str] = []
+
+    async def on_compaction(summary: str) -> None:
+        received.append(summary)
+
+    harness, mock_agent = _make_harness(tmp_path, on_compaction=on_compaction)
+    mock_agent.arun = AsyncMock(return_value=SimpleNamespace(content="flushed"))
+
+    # Mock session_summary_manager to return a summary
+    mock_ssm = MagicMock()
+    mock_ssm.create_session_summary.return_value = "Session summary text"
+    mock_agent.session_summary_manager = mock_ssm
+    mock_agent.get_session.return_value = SimpleNamespace(session_id="s-1")
+
+    await harness.compact_session()
+
+    assert received == ["Session summary text"]
+
+
+@pytest.mark.asyncio
+async def test_on_compaction_not_called_when_no_summary(tmp_path):
+    """on_compaction is NOT called when there's no summary to report."""
+    received: list[str] = []
+
+    async def on_compaction(summary: str) -> None:
+        received.append(summary)
+
+    harness, mock_agent = _make_harness(tmp_path, on_compaction=on_compaction)
+    mock_agent.arun = AsyncMock(return_value=SimpleNamespace(content="flushed"))
+    mock_agent.session_summary_manager = None
+
+    await harness.compact_session()
+
+    assert received == []
+
+
+# ── end_session + on_session_end callback ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_end_session_generates_summary_and_fires_callback(tmp_path):
+    """end_session() generates a summary and fires on_session_end."""
+    received: list[str] = []
+
+    async def on_session_end(summary: str) -> None:
+        received.append(summary)
+
+    harness, mock_agent = _make_harness(tmp_path, on_session_end=on_session_end)
+
+    # Mock chat history so _generate_session_summary has messages
+    mock_agent.get_chat_history.return_value = [
+        SimpleNamespace(role="user", content="hello"),
+        SimpleNamespace(role="assistant", content="world"),
+    ]
+    # Mock arun to return the summary response
+    mock_agent.arun = AsyncMock(
+        return_value=SimpleNamespace(content="- Decision 1\n- Decision 2")
+    )
+
+    result = await harness.end_session()
+
+    assert result == "- Decision 1\n- Decision 2"
+    assert received == ["- Decision 1\n- Decision 2"]
+
+
+@pytest.mark.asyncio
+async def test_end_session_skips_summary_when_disabled(tmp_path):
+    """end_session(generate_summary=False) skips LLM call and callback."""
+    received: list[str] = []
+
+    async def on_session_end(summary: str) -> None:
+        received.append(summary)
+
+    harness, mock_agent = _make_harness(tmp_path, on_session_end=on_session_end)
+    mock_agent.arun = AsyncMock()
+
+    result = await harness.end_session(generate_summary=False)
+
+    assert result is None
+    assert received == []
+    mock_agent.arun.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_end_session_no_callback_still_returns_summary(tmp_path):
+    """end_session() works without on_session_end callback."""
+    harness, mock_agent = _make_harness(tmp_path)
+
+    mock_agent.get_chat_history.return_value = [
+        SimpleNamespace(role="user", content="hi"),
+    ]
+    mock_agent.arun = AsyncMock(
+        return_value=SimpleNamespace(content="summary")
+    )
+
+    result = await harness.end_session()
+
+    assert result == "summary"

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "agnoclaw"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },


### PR DESCRIPTION
## Summary
- **skills_dirs** on constructor — register skill directories before system prompt is built
- **output_schema** as first-class parameter on `run()`/`arun()`
- **on_compaction** callback — fired after `compact_session()` with summary text
- **end_session()** + **on_session_end** callback — clean session teardown with LLM-generated summary
- **session_metadata** dict — merged into every HarnessEvent payload for platform routing
- Version bump 0.3.0 → 0.4.0, fix project URLs, add PyPI publish workflow

## Test plan
- [x] 567 tests passing (8 new), 0 failures
- [x] `uv build` produces `agnoclaw-0.4.0` sdist + wheel
- [x] Import verified: `agnoclaw.__version__ == "0.4.0"`
- [ ] After merge: tag `v0.4.0`, configure PyPI trusted publisher, push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)