### PR TITLE
Unify runtime backends and add llm-sandbox integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,22 +189,57 @@ For the unified Claude Code + OpenClaw gap status (implemented/remaining roadmap
 
 ## Sandboxed Backends
 
-The built-in workspace tool family is now backend-swappable. `agnoclaw` still owns prompts, sessions, hooks, policy, permissions, and guardrails, but you can replace the runtime plane behind:
+`agnoclaw` now exposes one coherent runtime override: `backend=...`.
+
+The harness still owns prompts, sessions, hooks, policy, permissions, and guardrails. The backend owns the execution plane behind:
 
 - `bash` / `bash_start` / `bash_output` / `bash_kill`
 - `read_file` / `write_file` / `edit_file` / `multi_edit_file` / `glob_files` / `grep_files` / `list_dir`
+- skill inline commands, dependency probes, and installs
+- browser tools, when enabled
 
-Inject custom backends with `AgentHarness(command_executor=..., workspace_adapter=...)` or `get_default_tools(...)`. The same backend pair is also propagated into built-in subagents and team presets so tool behavior stays coherent across nested runs.
+The same backend object is propagated into built-in subagents and team presets so nested runs stay on one runtime plane.
 
 ```python
-from agnoclaw import AgentHarness
+from agnoclaw import AgentHarness, RuntimeBackend
+
+
+class MySandboxBackend(RuntimeBackend):
+    def __init__(self, sandbox):
+        super().__init__(
+            command_executor=SandboxExecutor(sandbox),
+            workspace_adapter=SandboxWorkspace(sandbox),
+            browser_backend=SandboxBrowser(sandbox),
+        )
 
 agent = AgentHarness(
     workspace_dir="/srv/workspace",
-    command_executor=my_sandbox_executor,
-    workspace_adapter=my_sandbox_workspace,
+    backend=MySandboxBackend(sandbox),
 )
 ```
+
+Host mode remains the default: if you do not pass `backend=...`, `agnoclaw` uses local host implementations for shell, files, skills, and browser.
+
+Optional first-party `llm-sandbox` integration is available as `agnoclaw[llm-sandbox]`.
+
+```python
+from agnoclaw import AgentHarness
+from agnoclaw.integrations import LLMSandboxBackend
+
+backend = LLMSandboxBackend(
+    sync_paths=["workspace/inputs"],
+)
+
+agent = AgentHarness(
+    workspace_dir="/srv/workspace",
+    backend=backend,
+)
+
+# Pull back only the files you want from the sandbox.
+backend.sync_from_runtime("workspace/outputs")
+```
+
+`LLMSandboxBackend` is Docker-first, keeps the same absolute workspace paths inside the sandbox, and does not silently copy the whole workspace. Consumers decide what to `sync_to_runtime()` and `sync_from_runtime()`. Browser tools still require a separate browser backend.
 
 More detail: [`docs/embedding/workspace-backends.md`](docs/embedding/workspace-backends.md)
 

--- a/docs/embedding/README.md
+++ b/docs/embedding/README.md
@@ -9,7 +9,8 @@ This folder documents how to embed the harness core inside another service.
 - Policy checkpoints across run and tool boundaries.
 - Structured events via pluggable event sinks.
 - Runtime path/network guardrails.
-- Backend injection for built-in workspace tools.
+- Single-backend runtime injection for built-in tools, skills, and browser.
+- Optional first-party `LLMSandboxBackend` for Docker-first sandbox execution.
 - Optional AgentOS claim-to-context adapter.
 
 ## Minimal embedding pattern
@@ -41,12 +42,12 @@ print(result.content)
 - Harness emits lifecycle events for run/prompt/model/policy/tool checkpoints.
 - Policy denials return typed `HarnessError` values.
 - Tool calls are checked by guardrails before execution.
-- Built-in `bash` and `files` tools can target a custom execution/filesystem backend.
+- Built-in tools and skill installs can target one coherent custom backend.
 - Run metadata includes normalized execution context for downstream tooling.
 
 ## Related docs
 
 - [Policy and Guardrails](./policy-and-guardrails.md)
-- [Workspace Backends](./workspace-backends.md)
+- [Runtime Backends](./workspace-backends.md)
 - [AgentOS Adapter](./agentos-adapter.md)
 - [v0.2 Spec](../../spec/v0.2-harness-core.md)

--- a/docs/embedding/workspace-backends.md
+++ b/docs/embedding/workspace-backends.md
@@ -1,112 +1,166 @@
-# Workspace Backends
+# Runtime Backends
 
-`agnoclaw` can now separate orchestration from the underlying execution/filesystem plane for its built-in workspace tool family.
+`agnoclaw` separates orchestration from execution with one public integration point:
 
-This matters for hosted or sandboxed runtimes where:
+- `AgentHarness(..., backend=...)`
+- `get_default_tools(..., backend=...)`
+- built-in team factories such as `code_team(..., backend=...)`
+- built-in `spawn_subagent`, which inherits the same backend automatically
 
-- shell commands must run in a container or remote sandbox
-- file operations must read/write the sandbox filesystem, not the host process filesystem
-- `bash` and `files` need to stay coherent instead of pointing at different environments
+## Design intent
 
-## Extension points
+The backend object is the runtime boundary.
 
-Two tool-level backend interfaces are available:
+That means one backend owns:
 
-- `CommandExecutor`
-- `WorkspaceAdapter`
+- shell execution
+- file access
+- skill inline command execution
+- skill dependency probes and installs
+- browser automation, when enabled
 
-The default implementations remain host-local:
+The goal is to avoid split-brain setups where `bash` runs in a sandbox, files touch the host, or skill installs happen somewhere different from later command execution.
 
-- `LocalCommandExecutor`
-- `LocalWorkspaceAdapter`
+## Host mode
 
-## What they cover
+If you do not pass `backend=...`, `agnoclaw` uses host-local implementations for:
 
-`CommandExecutor` backs:
+- bash tools
+- file tools
+- skill runtime behavior
+- browser tools
 
-- `bash`
-- `bash_start`
-- `bash_output`
-- `bash_kill`
+This is the default local developer experience.
 
-`WorkspaceAdapter` backs:
+## Custom backend rules
 
-- `read_file`
-- `write_file`
-- `edit_file`
-- `multi_edit_file`
-- `glob_files`
-- `grep_files`
-- `list_dir`
+Custom backends should be passed as a single object.
 
-These backends can be injected through:
+Two safety rules matter:
 
-- `AgentHarness(...)`
-- `get_default_tools(...)`
-- team factories such as `code_team(...)` and `data_team(...)`
-- subagents spawned through the built-in `spawn_subagent` tool
+1. A composed `RuntimeBackend(...)` must receive both `command_executor` and `workspace_adapter` together, or neither.
+2. Once a custom backend is in use, missing capabilities do not silently fall back to the host.
 
-## Example
+In practice:
+
+- if your backend does not provide shell and file support, backend resolution fails
+- if browser tools are enabled and your backend does not provide browser support, tool construction fails explicitly
+
+## Recommended integration shape
+
+Consumer code should wrap its sandbox/session object in one backend class.
+
+This matches how current sandbox SDKs are typically structured: a single sandbox/session object exposes command execution and filesystem access from one handle.
 
 ```python
-from agnoclaw import AgentHarness
-from agnoclaw.tools import CommandExecutor, WorkspaceAdapter
+from agnoclaw import AgentHarness, RuntimeBackend
 
 
-class SandboxExecutor(CommandExecutor):
-    def run(self, *, command, workdir, timeout_seconds):
-        ...
+class E2BLikeBackend(RuntimeBackend):
+    def __init__(self, sandbox):
+        self.sandbox = sandbox
 
-    def start(self, *, command, workdir, description=None):
-        ...
+    def resolve_command_executor(self, *, workspace_dir):
+        return SandboxCommandExecutor(self.sandbox, workspace_dir=workspace_dir)
 
-    def output(self, *, task_id, max_chars=8000, tail=True):
-        ...
+    def resolve_workspace_adapter(self, *, workspace_dir):
+        return SandboxWorkspaceAdapter(self.sandbox, workspace_dir=workspace_dir)
 
-    def kill(self, *, task_id, force=False):
-        ...
-
-
-class SandboxWorkspace(WorkspaceAdapter):
-    workspace_dir = "/sandbox/workspace"
-
-    def read_file(self, path, offset=0, limit=2000):
-        ...
-
-    def write_file(self, path, content):
-        ...
-
-    def edit_file(self, path, old_string, new_string):
-        ...
-
-    def multi_edit_file(self, path, edits):
-        ...
-
-    def glob_files(self, pattern, base_dir=None, path=None):
-        ...
-
-    def grep_files(self, pattern, path=None, glob=None, case_insensitive=False, context_lines=0, max_results=50):
-        ...
-
-    def list_dir(self, path=None):
-        ...
+    def resolve_browser_backend(self):
+        return SandboxBrowserBackend(self.sandbox)
 
 
 agent = AgentHarness(
-    workspace_dir="/logical/workspace",
-    command_executor=SandboxExecutor(),
-    workspace_adapter=SandboxWorkspace(),
+    workspace_dir="/srv/workspace",
+    backend=E2BLikeBackend(sandbox),
 )
 ```
 
-## Architectural boundary
+This is the intended consumer-facing pattern for E2B-style or LLM-sandbox-style integrations.
 
-This backend abstraction does not replace policy or guardrails.
+## First-party LLMSandboxBackend
 
-The layering is:
+`agnoclaw` now ships an optional first-party `LLMSandboxBackend` in
+`agnoclaw.integrations`.
 
-1. `AgentHarness` owns prompts, sessions, hooks, events, policy, permissions, and guardrails.
-2. Built-in workspace tools delegate execution/storage to the injected backends.
-3. Your sandbox/container/remote runtime owns the actual command execution and filesystem behavior.
+Install it with:
 
-That keeps the harness opinionated at the orchestration layer while allowing embedders to control the runtime plane.
+```bash
+uv sync --extra llm-sandbox
+```
+
+Use it like this:
+
+```python
+from agnoclaw import AgentHarness
+from agnoclaw.integrations import LLMSandboxBackend
+
+backend = LLMSandboxBackend(
+    sync_paths=["workspace/inputs"],
+)
+
+agent = AgentHarness(
+    workspace_dir="/srv/workspace",
+    backend=backend,
+)
+
+# Later, pull selected outputs back to the host.
+backend.sync_from_runtime("workspace/outputs")
+```
+
+Important behavior:
+
+- it is Docker-first by default
+- it mirrors the same absolute workspace paths inside the sandbox
+- it does not auto-copy the entire workspace
+- `bash`, file tools, and skill installs all run against the same sandbox session
+- browser tools still require a separate browser backend
+- consumers explicitly choose which paths to push or pull
+
+This keeps one coherent runtime plane without guessing which host paths should be
+present inside the sandbox.
+
+## Advanced composition
+
+For tests or thin embeddings, `RuntimeBackend` can also compose lower-level adapters directly:
+
+```python
+from agnoclaw import AgentHarness, RuntimeBackend
+
+backend = RuntimeBackend(
+    command_executor=SandboxExecutor(sandbox),
+    workspace_adapter=SandboxWorkspace(sandbox),
+    browser_backend=SandboxBrowser(sandbox),
+)
+
+agent = AgentHarness(workspace_dir="/srv/workspace", backend=backend)
+```
+
+This is supported, but the cleaner public experience is still “wrap one sandbox/session object once, pass one backend everywhere.”
+
+## What the backend covers
+
+`RuntimeBackend` resolution feeds:
+
+- `bash`, `bash_start`, `bash_output`, `bash_kill`
+- `read_file`, `write_file`, `edit_file`, `multi_edit_file`, `glob_files`, `grep_files`, `list_dir`
+- skill `!` inline command execution for trusted skills
+- skill install checks and dependency installs
+- `BrowserToolkit`, when browser tools are enabled
+
+## What it does not replace
+
+The backend abstraction does not replace:
+
+- prompts
+- sessions and storage
+- event sinks
+- policy checkpoints
+- permission approval
+- path/network guardrails
+
+The layering stays:
+
+1. `AgentHarness` owns orchestration, policy, permissions, hooks, and guardrails.
+2. `RuntimeBackend` owns the runtime plane.
+3. Your sandbox/container/remote service owns the actual execution and storage semantics.

--- a/docs/harness-gap-analysis.md
+++ b/docs/harness-gap-analysis.md
@@ -47,7 +47,7 @@ Deferred by design:
 - Skill `command-dispatch: tool` enforcement (bypasses LLM, invokes tool directly)
 - ClawHub integration (search, inspect, install community skills)
 - Auto-skill selection (skill catalog injected into system prompt)
-- Pluggable built-in workspace backends (`CommandExecutor`, `WorkspaceAdapter`)
+- Single runtime backend abstraction for built-in tools, skills, and browser
 
 ---
 
@@ -62,8 +62,8 @@ Deferred by design:
 | Elevated execution path | Bypass/elevation semantics | Elevated mode (`!`) | **Missing** | High | Harness |
 | Tool boundary policy interception | Pre/post tool controls | Hooks around command/tool lifecycle | **Implemented** | Low | Harness |
 | Runtime guardrails | Permission/sandbox controls | Sandboxing/security controls | **Implemented (path/network)** | Low | Harness |
-| Built-in workspace backend abstraction | Tool family can target alternate runtime plane | Exec/files tools can bind to sandbox/container workspace | **Implemented** (`CommandExecutor`, `WorkspaceAdapter`) | ~~High~~ Done | Harness |
-| Sandbox provider abstraction | Multiple runtime permission/sandbox modes | Sandboxing modes (`workspace-write/read-only/full`) | **Partial** (policy + guardrails, no provider backends) | High | Harness |
+| Built-in runtime backend abstraction | Tool family can target one alternate runtime plane | Exec/files/browser/skills bind to sandbox/container workspace | **Implemented** (`RuntimeBackend`) | ~~High~~ Done | Harness |
+| Sandbox provider abstraction | Multiple runtime permission/sandbox modes | Sandboxing modes (`workspace-write/read-only/full`) | **Partial** (single backend contract exists; first-party `LLMSandboxBackend` ships, other provider adapters still open) | High | Harness |
 | Hook breadth and packaging | 17 events + multiple hook types | Plugin hook packs + lifecycle events | **Partial** (run + tool path) | High | Harness |
 | Scheduler | None | Heartbeat + Cron | **Implemented** | Low | Harness |
 | Persistent cron management | N/A | Durable job management | **Partial** (in-memory jobs) | Medium | Harness |
@@ -96,7 +96,7 @@ Newly closed or reduced gaps (v0.3):
 8. **Skill `command-dispatch: tool` enforcement** — Bypasses LLM, invokes the specified tool directly.
 9. **ClawHub integration** — HTTP client for community skill registry (search, inspect, download, install).
 10. **Auto-skill selection** — Skill catalog injected into system prompt so model can self-select relevant skills.
-11. **Pluggable workspace tool backends** — Built-in bash/files tools now accept injected execution/filesystem backends, with propagation into subagents and team presets.
+11. **Single runtime backend propagation** — Built-in bash/files, trusted skill execution/install flow, browser tools, subagents, and team presets now share one injected runtime backend.
 
 Previously closed:
 1. Runtime permission modes are now implemented in the harness core.

--- a/examples/llm_sandbox_backend.py
+++ b/examples/llm_sandbox_backend.py
@@ -1,0 +1,27 @@
+"""Run agnoclaw against a Docker-backed llm-sandbox session."""
+
+from agnoclaw import AgentHarness
+from agnoclaw.integrations import LLMSandboxBackend
+
+
+def main() -> None:
+    workspace_dir = "workspace"
+    backend = LLMSandboxBackend(
+        sync_paths=["workspace/inputs"],
+    ).bind(workspace_dir)
+
+    agent = AgentHarness(
+        "anthropic:claude-sonnet-4-6",
+        workspace_dir=workspace_dir,
+        backend=backend,
+    )
+    agent.print_response(
+        "Summarize the files under workspace/inputs and write a short report to "
+        "workspace/outputs/report.md",
+        stream=True,
+    )
+    backend.sync_from_runtime("workspace/outputs")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.7.0"
+version = "0.7.1"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }
@@ -83,6 +83,10 @@ all-models = [
 # Browser automation (Playwright)
 browser = [
     "playwright>=1.40.0",
+]
+# Docker-first llm-sandbox runtime integration
+llm-sandbox = [
+    "llm-sandbox[docker]>=0.3.31",
 ]
 # MCP (Model Context Protocol) server integration
 mcp = [

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -24,13 +24,14 @@ With skills:
 """
 
 from .agent import AgentHarness, HarnessAgent  # HarnessAgent = backward compat alias
+from .backends import RuntimeBackend
 from .config import HarnessConfig, get_config
 from .runtime import (
-    AllowAllPolicyEngine,
-    AgnoAuthError,
-    AgnoConfigError,
     AgentOSClaimKeys,
     AgentOSContextAdapter,
+    AgnoAuthError,
+    AgnoConfigError,
+    AllowAllPolicyEngine,
     EventSinkMode,
     ExecutionContext,
     GuardrailViolation,
@@ -42,9 +43,12 @@ from .runtime import (
     PolicyDecision,
     RuntimeGuardrails,
 )
+from .skills import AutoApproveSkillInstallApprover, InteractiveSkillInstallApprover
 from .tools import (
+    BrowserBackend,
     CommandExecutor,
     LocalCommandExecutor,
+    LocalPlaywrightBrowserBackend,
     LocalWorkspaceAdapter,
     WorkspaceAdapter,
 )
@@ -58,6 +62,8 @@ __all__ = [
     "AgentOSClaimKeys",
     "AgentOSContextAdapter",
     "AgentHarness",
+    "AutoApproveSkillInstallApprover",
+    "BrowserBackend",
     "EventSinkMode",
     "ExecutionContext",
     "GuardrailViolation",
@@ -65,13 +71,16 @@ __all__ = [
     "HarnessConfig",
     "HarnessError",
     "InMemoryEventSink",
+    "InteractiveSkillInstallApprover",
     "CommandExecutor",
     "LocalCommandExecutor",
+    "LocalPlaywrightBrowserBackend",
     "LocalWorkspaceAdapter",
     "PermissionController",
     "PermissionMode",
     "PolicyAction",
     "PolicyDecision",
+    "RuntimeBackend",
     "RuntimeGuardrails",
     "get_config",
     "SubagentDefinition",
@@ -79,4 +88,4 @@ __all__ = [
     "Workspace",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -70,12 +70,13 @@ from agno.run.agent import RunOutput, RunOutputEvent
 from agno.tools.function import Function
 from agno.tools.toolkit import Toolkit
 
+from .backends import RuntimeBackend
 from .config import HarnessConfig, get_config
 from .prompts.system import SystemPromptBuilder
 from .runtime import (
-    AllowAllPolicyEngine,
     AgnoAuthError,
     AgnoConfigError,
+    AllowAllPolicyEngine,
     EventSink,
     EventSinkMode,
     ExecutionContext,
@@ -100,6 +101,7 @@ from .runtime import (
     build_event,
     normalize_permission_mode,
 )
+from .skills.backends import SkillInstallApprover
 from .skills.registry import SkillRegistry
 from .tools import get_default_tools
 from .workspace import Workspace
@@ -299,8 +301,8 @@ class AgentHarness:
                          "bypass", "default", "accept_edits", "plan", "dont_ask".
         permission_approver: Optional approval callback used in non-bypass modes.
         permission_require_approver: If True, deny approval-required calls when no approver exists.
-        command_executor: Optional backend override for built-in bash tools.
-        workspace_adapter: Optional backend override for built-in file tools.
+        backend: Optional coherent runtime backend for tools/skills/browser.
+        skill_install_approver: Optional approval backend for skill dependency installs.
     """
 
     def __init__(
@@ -344,8 +346,8 @@ class AgentHarness:
         permission_require_approver: bool | None = None,
         permission_preapproved_tools: list[str] | tuple[str, ...] | None = None,
         permission_preapproved_categories: list[str] | tuple[str, ...] | None = None,
-        command_executor=None,
-        workspace_adapter=None,
+        backend: RuntimeBackend | None = None,
+        skill_install_approver: SkillInstallApprover | None = None,
         pre_run_hooks: list[PreRunHook] | None = None,
         post_run_hooks: list[PostRunHook] | None = None,
         tenant_id: str | None = None,
@@ -455,6 +457,9 @@ class AgentHarness:
             project_dir=self.config.project_workspace_dir,
         )
         self.workspace.initialize()
+        effective_backend = backend or RuntimeBackend()
+        resolved_backend = effective_backend.resolve(workspace_dir=self.workspace.path)
+        resolved_skill_runtime_backend = resolved_backend.skill_runtime
         self._guardrails = RuntimeGuardrails(
             workspace_dir=self.workspace.path,
             enabled=self.config.guardrails_enabled,
@@ -470,7 +475,12 @@ class AgentHarness:
         )
 
         # Skills registry
-        self.skills = SkillRegistry(self.workspace.skills_dir())
+        self.skills = SkillRegistry(
+            self.workspace.skills_dir(),
+            runtime_backend=resolved_skill_runtime_backend,
+            install_approver=skill_install_approver,
+            working_dir=self.workspace.path,
+        )
         if skills_dirs:
             for path, trust in skills_dirs:
                 self.skills.add_directory(path, trust=trust)
@@ -492,8 +502,7 @@ class AgentHarness:
                 self.config,
                 subagents=subagents,
                 workspace_dir=self.workspace.path,
-                command_executor=command_executor,
-                workspace_adapter=workspace_adapter,
+                backend=effective_backend,
             )
         if _tools:
             _all_tools.extend(_tools)
@@ -516,12 +525,20 @@ class AgentHarness:
             self._post_run_hooks.extend(self._plugin_loader.get_all_post_run_hooks())
 
             if manifests:
-                logger.info("Loaded %d plugin(s): %s", len(manifests), ", ".join(m.name for m in manifests))
+                logger.info(
+                    "Loaded %d plugin(s): %s",
+                    len(manifests),
+                    ", ".join(m.name for m in manifests),
+                )
 
         self._attach_tool_runtime_hooks(_all_tools)
 
         # Resolve learning flags before building system prompt
-        _enable_learning = enable_learning if enable_learning is not None else self.config.enable_learning
+        _enable_learning = (
+            enable_learning
+            if enable_learning is not None
+            else self.config.enable_learning
+        )
         _learning_mode = learning_mode or self.config.learning_mode
 
         # Persist prompt options so per-run skill injection can be one-shot

--- a/src/agnoclaw/backends.py
+++ b/src/agnoclaw/backends.py
@@ -1,0 +1,123 @@
+"""Single coherent runtime backend for host and sandboxed deployments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .skills.backends import (
+    CommandExecutorSkillRuntimeBackend,
+    LocalSkillRuntimeBackend,
+    SkillRuntimeBackend,
+)
+from .tools.backends import (
+    CommandExecutor,
+    LocalCommandExecutor,
+    LocalWorkspaceAdapter,
+    WorkspaceAdapter,
+)
+from .tools.browser_backends import BrowserBackend
+
+
+@dataclass(frozen=True)
+class ResolvedRuntimeBackend:
+    """Resolved runtime capabilities for one concrete workspace."""
+
+    command_executor: CommandExecutor
+    workspace_adapter: WorkspaceAdapter
+    skill_runtime: SkillRuntimeBackend
+    browser_backend: BrowserBackend | None = None
+
+
+class RuntimeBackend:
+    """
+    Single runtime backend override for shell, files, skills, and browser tools.
+
+    Consumers should pass one backend object to `AgentHarness(..., backend=...)`.
+    Advanced integrations can either subclass this type around a sandbox/session
+    object, or compose one from lower-level adapters in tests and embeddings.
+    """
+
+    def __init__(
+        self,
+        *,
+        command_executor: CommandExecutor | None = None,
+        workspace_adapter: WorkspaceAdapter | None = None,
+        browser_backend: BrowserBackend | None = None,
+    ) -> None:
+        if (command_executor is None) != (workspace_adapter is None):
+            raise ValueError(
+                "RuntimeBackend requires both command_executor and "
+                "workspace_adapter together, or neither."
+            )
+        self._command_executor = command_executor
+        self._workspace_adapter = workspace_adapter
+        self._browser_backend = browser_backend
+
+    def uses_host_runtime(self) -> bool:
+        """Return True only for the default host-local backend mode."""
+        return (
+            type(self) is RuntimeBackend
+            and self._command_executor is None
+            and self._workspace_adapter is None
+            and self._browser_backend is None
+        )
+
+    def resolve(
+        self,
+        *,
+        workspace_dir: str | Path,
+    ) -> ResolvedRuntimeBackend:
+        workspace_path = Path(workspace_dir).expanduser().resolve()
+        command_executor = self.resolve_command_executor(workspace_dir=workspace_path)
+        workspace_adapter = self.resolve_workspace_adapter(workspace_dir=workspace_path)
+        return ResolvedRuntimeBackend(
+            command_executor=command_executor,
+            workspace_adapter=workspace_adapter,
+            skill_runtime=self.resolve_skill_runtime(
+                workspace_dir=workspace_path,
+                command_executor=command_executor,
+            ),
+            browser_backend=self.resolve_browser_backend(),
+        )
+
+    def resolve_command_executor(self, *, workspace_dir: str | Path) -> CommandExecutor:
+        if self._command_executor is not None:
+            return self._command_executor
+        if self.uses_host_runtime():
+            return LocalCommandExecutor(workspace_dir=workspace_dir)
+        raise RuntimeError(
+            "This backend must provide command execution. "
+            "Override resolve_command_executor() or pass command_executor and "
+            "workspace_adapter together."
+        )
+
+    def resolve_workspace_adapter(self, *, workspace_dir: str | Path) -> WorkspaceAdapter:
+        if self._workspace_adapter is not None:
+            return self._workspace_adapter
+        if self.uses_host_runtime():
+            return LocalWorkspaceAdapter(workspace_dir=workspace_dir)
+        raise RuntimeError(
+            "This backend must provide workspace file access. "
+            "Override resolve_workspace_adapter() or pass command_executor and "
+            "workspace_adapter together."
+        )
+
+    def resolve_skill_runtime(
+        self,
+        *,
+        workspace_dir: str | Path,
+        command_executor: CommandExecutor | None = None,
+    ) -> SkillRuntimeBackend:
+        if self.uses_host_runtime():
+            return LocalSkillRuntimeBackend(working_dir=workspace_dir)
+        resolved_command_executor = command_executor or self.resolve_command_executor(
+            workspace_dir=workspace_dir
+        )
+        return CommandExecutorSkillRuntimeBackend(
+            resolved_command_executor,
+            working_dir=workspace_dir,
+        )
+
+    def resolve_browser_backend(self) -> BrowserBackend | None:
+        return self._browser_backend

--- a/src/agnoclaw/integrations/__init__.py
+++ b/src/agnoclaw/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Optional first-party integrations for sandbox and provider runtimes."""
+
+from .llm_sandbox import LLMSandboxBackend
+
+__all__ = ["LLMSandboxBackend"]

--- a/src/agnoclaw/integrations/llm_sandbox.py
+++ b/src/agnoclaw/integrations/llm_sandbox.py
@@ -1,0 +1,570 @@
+"""Optional llm-sandbox runtime backend integration."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import tempfile
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from agnoclaw.backends import RuntimeBackend
+from agnoclaw.tools.backends import (
+    BackgroundCommandHandle,
+    BackgroundCommandOutput,
+    CommandResult,
+    LocalWorkspaceAdapter,
+)
+from agnoclaw.tools.browser_backends import BrowserBackend
+
+
+@dataclass(frozen=True)
+class _BackgroundTask:
+    task_id: str
+    pid: int
+    log_path: str
+    exit_path: str
+    pid_path: str
+    description: str | None = None
+
+
+def _load_llm_sandbox() -> tuple[Any, Any]:
+    try:
+        from llm_sandbox import SandboxSession
+        from llm_sandbox.const import SandboxBackend
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise ImportError(
+            "LLMSandboxBackend requires the optional llm-sandbox integration. "
+            "Install it with `pip install 'agnoclaw[llm-sandbox]'`."
+        ) from exc
+    return SandboxSession, SandboxBackend
+
+
+class LLMSandboxCommandExecutor:
+    """Command executor backed by one llm-sandbox session."""
+
+    def __init__(
+        self,
+        *,
+        session: Any,
+        workspace_dir: Path,
+        task_dir: str,
+        max_background_tasks: int = 16,
+    ) -> None:
+        self._session = session
+        self.workspace_dir = str(workspace_dir)
+        self._task_dir = task_dir
+        self._max_background_tasks = max_background_tasks
+        self._tasks: dict[str, _BackgroundTask] = {}
+
+    def run(
+        self,
+        *,
+        command: str,
+        workdir: str | None,
+        timeout_seconds: int | None,
+    ) -> CommandResult:
+        del timeout_seconds
+        started = time.monotonic()
+        result = self._session.execute_command(
+            command=command,
+            workdir=self._resolve_workdir(workdir),
+        )
+        return CommandResult(
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            exit_code=int(result.exit_code),
+            duration_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    def start(
+        self,
+        *,
+        command: str,
+        workdir: str | None,
+        description: str | None = None,
+    ) -> BackgroundCommandHandle:
+        self._prune_finished_tasks()
+        if len(self._tasks) >= self._max_background_tasks:
+            raise RuntimeError(
+                f"[error] Too many background tasks ({len(self._tasks)}). "
+                "Use bash_kill or wait for tasks to finish."
+            )
+
+        task_id = f"task_{uuid4().hex[:12]}"
+        log_path = f"{self._task_dir}/{task_id}.log"
+        exit_path = f"{self._task_dir}/{task_id}.exit"
+        pid_path = f"{self._task_dir}/{task_id}.pid"
+        inner = self._build_background_script(
+            command=command,
+            workdir=self._resolve_workdir(workdir),
+            exit_path=exit_path,
+        )
+        shell_command = (
+            f"mkdir -p {shlex.quote(self._task_dir)} && "
+            f"nohup sh -lc {shlex.quote(inner)} > {shlex.quote(log_path)} 2>&1 < /dev/null & "
+            f"pid=$!; printf '%s' \"$pid\" > {shlex.quote(pid_path)}; printf '%s' \"$pid\""
+        )
+        result = self._session.execute_command(command=shell_command, workdir=None)
+        if int(result.exit_code) != 0:
+            raise RuntimeError(result.stderr or result.stdout or "failed to start background task")
+        try:
+            pid = int((result.stdout or "").strip().splitlines()[-1])
+        except Exception as exc:
+            raise RuntimeError("failed to capture background task pid") from exc
+
+        self._tasks[task_id] = _BackgroundTask(
+            task_id=task_id,
+            pid=pid,
+            log_path=log_path,
+            exit_path=exit_path,
+            pid_path=pid_path,
+            description=description,
+        )
+        return BackgroundCommandHandle(
+            task_id=task_id,
+            pid=pid,
+            status="running",
+            log_path=log_path,
+        )
+
+    def output(
+        self,
+        *,
+        task_id: str,
+        max_chars: int = 8000,
+        tail: bool = True,
+    ) -> BackgroundCommandOutput:
+        task = self._require_task(task_id)
+        status, exit_code = self._task_status(task)
+        output = self._read_runtime_text(task.log_path)
+        return BackgroundCommandOutput(
+            task_id=task.task_id,
+            status=status,
+            output=self._truncate_output(output, max_chars=max_chars, tail=tail),
+            exit_code=exit_code,
+            pid=task.pid,
+        )
+
+    def kill(self, *, task_id: str, force: bool = False) -> str:
+        task = self._require_task(task_id)
+        signal = "-9" if force else "-TERM"
+        command = (
+            f"if kill -0 {task.pid} 2>/dev/null; then "
+            f"kill {signal} {task.pid} 2>/dev/null || true; "
+            f"if command -v pkill >/dev/null 2>&1; then "
+            f"pkill {signal} -P {task.pid} 2>/dev/null || true; "
+            f"fi; "
+            f"printf 'terminated'; "
+            f"else printf 'not-running'; fi"
+        )
+        result = self._session.execute_command(command=command, workdir=None)
+        outcome = (result.stdout or "").strip() or "not-running"
+        if outcome == "terminated":
+            return f"Sent {'SIGKILL' if force else 'SIGTERM'} to task {task_id} (pid {task.pid})"
+        return f"Task {task_id} is not running"
+
+    def _resolve_workdir(self, workdir: str | None) -> str:
+        if workdir is None:
+            return self.workspace_dir
+        return str(Path(workdir).expanduser().resolve(strict=False))
+
+    @staticmethod
+    def _build_background_script(
+        *,
+        command: str,
+        workdir: str,
+        exit_path: str,
+    ) -> str:
+        return (
+            f"cd {shlex.quote(workdir)} || exit $?; "
+            f"{command}; "
+            f"code=$?; "
+            f"printf '%s' \"$code\" > {shlex.quote(exit_path)}; "
+            f"exit $code"
+        )
+
+    @staticmethod
+    def _truncate_output(text: str, *, max_chars: int, tail: bool) -> str:
+        if max_chars <= 0 or len(text) <= max_chars:
+            return text
+        if tail:
+            return f"... [truncated to last {max_chars} chars]\n{text[-max_chars:]}"
+        return text[:max_chars] + f"\n... [truncated to first {max_chars} chars]"
+
+    def _require_task(self, task_id: str) -> _BackgroundTask:
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise RuntimeError(f"Unknown background task: {task_id}")
+        return task
+
+    def _task_status(self, task: _BackgroundTask) -> tuple[str, int | None]:
+        command = (
+            f"if [ -f {shlex.quote(task.exit_path)} ]; then "
+            f"printf 'status=exited\\n'; "
+            f"printf 'exit_code='; cat {shlex.quote(task.exit_path)}; printf '\\n'; "
+            f"elif kill -0 {task.pid} 2>/dev/null; then "
+            f"printf 'status=running\\n'; "
+            f"else printf 'status=terminated\\n'; fi"
+        )
+        result = self._session.execute_command(command=command, workdir=None)
+        status = "terminated"
+        exit_code: int | None = None
+        for line in (result.stdout or "").splitlines():
+            if line.startswith("status="):
+                status = line.partition("=")[2].strip() or "terminated"
+            if line.startswith("exit_code="):
+                value = line.partition("=")[2].strip()
+                if value:
+                    try:
+                        exit_code = int(value)
+                    except ValueError:
+                        exit_code = None
+        return status, exit_code
+
+    def _read_runtime_text(self, runtime_path: str) -> str:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_path = Path(tmp_dir) / Path(runtime_path).relative_to("/")
+            try:
+                self._session.copy_from_runtime(runtime_path, str(local_path))
+            except FileNotFoundError:
+                return ""
+            return local_path.read_text(encoding="utf-8", errors="replace")
+
+    def _prune_finished_tasks(self) -> None:
+        if len(self._tasks) < self._max_background_tasks:
+            return
+        finished = [
+            task_id
+            for task_id, task in self._tasks.items()
+            if self._task_status(task)[0] != "running"
+        ]
+        for task_id in finished:
+            if len(self._tasks) < self._max_background_tasks:
+                break
+            self._tasks.pop(task_id, None)
+
+
+class LLMSandboxWorkspaceAdapter:
+    """Workspace adapter that copies files to and from one sandbox session."""
+
+    def __init__(self, *, session: Any, workspace_dir: Path) -> None:
+        self._session = session
+        self.workspace_dir = workspace_dir
+        self._local = LocalWorkspaceAdapter(workspace_dir=workspace_dir)
+
+    def read_file(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        runtime_path = self._resolve_path(path)
+        try:
+            with self._copied_from_runtime(runtime_path) as local_path:
+                return self._local.read_file(str(local_path), offset=offset, limit=limit)
+        except FileNotFoundError:
+            return f"[error] File not found: {runtime_path}"
+
+    def write_file(self, path: str, content: str) -> str:
+        runtime_path = self._resolve_path(path)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_path = Path(tmp_dir) / runtime_path.relative_to("/")
+            result = self._local.write_file(str(local_path), content)
+            self._copy_to_runtime(local_path, runtime_path)
+            return self._rewrite_paths(result, local_path, runtime_path)
+
+    def edit_file(self, path: str, old_string: str, new_string: str) -> str:
+        runtime_path = self._resolve_path(path)
+        try:
+            with self._copied_from_runtime(runtime_path) as local_path:
+                result = self._local.edit_file(str(local_path), old_string, new_string)
+                if result.startswith("[error]"):
+                    return self._rewrite_paths(result, local_path, runtime_path)
+                self._copy_to_runtime(local_path, runtime_path)
+                return self._rewrite_paths(result, local_path, runtime_path)
+        except FileNotFoundError:
+            return f"[error] File not found: {runtime_path}. Read the file first."
+
+    def multi_edit_file(self, path: str, edits: list[dict[str, str]]) -> str:
+        runtime_path = self._resolve_path(path)
+        try:
+            with self._copied_from_runtime(runtime_path) as local_path:
+                result = self._local.multi_edit_file(str(local_path), edits)
+                if result.startswith("[error]"):
+                    return self._rewrite_paths(result, local_path, runtime_path)
+                self._copy_to_runtime(local_path, runtime_path)
+                return self._rewrite_paths(result, local_path, runtime_path)
+        except FileNotFoundError:
+            return f"[error] File not found: {runtime_path}. Read the file first."
+
+    def glob_files(
+        self,
+        pattern: str,
+        base_dir: str | None = None,
+        path: str | None = None,
+    ) -> str:
+        if base_dir or path:
+            runtime_path = self._resolve_path(base_dir or path)
+        else:
+            runtime_path = self.workspace_dir
+        try:
+            with self._copied_from_runtime(runtime_path) as local_path:
+                result = self._local.glob_files(pattern=pattern, path=str(local_path))
+                return self._rewrite_paths(result, local_path, runtime_path)
+        except FileNotFoundError:
+            return f"[error] Directory not found: {runtime_path}"
+
+    def grep_files(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        case_insensitive: bool = False,
+        context_lines: int = 0,
+        max_results: int = 50,
+    ) -> str:
+        runtime_path = self._resolve_path(path) if path else self.workspace_dir
+        try:
+            with self._copied_from_runtime(runtime_path) as local_path:
+                result = self._local.grep_files(
+                    pattern=pattern,
+                    path=str(local_path),
+                    glob=glob,
+                    case_insensitive=case_insensitive,
+                    context_lines=context_lines,
+                    max_results=max_results,
+                )
+                return self._rewrite_paths(result, local_path, runtime_path)
+        except FileNotFoundError:
+            return f"[error] Directory not found: {runtime_path}"
+
+    def list_dir(self, path: str | None = None) -> str:
+        runtime_path = self._resolve_path(path) if path else self.workspace_dir
+        try:
+            with self._copied_from_runtime(runtime_path) as local_path:
+                result = self._local.list_dir(str(local_path))
+                return self._rewrite_paths(result, local_path, runtime_path)
+        except FileNotFoundError:
+            return f"[error] Directory not found: {runtime_path}"
+
+    def _resolve_path(self, path: str | None) -> Path:
+        if path is None:
+            return self.workspace_dir
+        candidate = Path(path).expanduser()
+        if not candidate.is_absolute():
+            candidate = self.workspace_dir / candidate
+        return candidate.resolve(strict=False)
+
+    def _copied_from_runtime(self, runtime_path: Path):
+        adapter = self
+
+        class _RuntimeCopyContext:
+            def __enter__(self_nonlocal) -> Path:
+                self_nonlocal._tmp_dir = tempfile.TemporaryDirectory()
+                local_path = Path(self_nonlocal._tmp_dir.name) / runtime_path.relative_to("/")
+                copied_path = _copy_from_runtime_path(
+                    adapter._session,
+                    runtime_path=runtime_path,
+                    local_path=local_path,
+                )
+                self_nonlocal._local_path = copied_path
+                return copied_path
+
+            def __exit__(self_nonlocal, exc_type, exc, tb) -> None:
+                self_nonlocal._tmp_dir.cleanup()
+
+        return _RuntimeCopyContext()
+
+    def _copy_to_runtime(self, local_path: Path, runtime_path: Path) -> None:
+        self._session.execute_command(
+            command=f"mkdir -p {shlex.quote(str(runtime_path.parent))}",
+            workdir=None,
+        )
+        self._session.copy_to_runtime(str(local_path), str(runtime_path))
+
+    @staticmethod
+    def _rewrite_paths(result: str, local_path: Path, runtime_path: Path) -> str:
+        return result.replace(str(local_path), str(runtime_path))
+
+
+class LLMSandboxBackend(RuntimeBackend):
+    """
+    Docker-first llm-sandbox integration with explicit workspace sync.
+
+    By default this backend creates an llm-sandbox Docker session, mirrors the
+    same absolute workspace path inside the sandbox, and keeps later sync
+    decisions explicit through `sync_to_runtime()` and `sync_from_runtime()`.
+    """
+
+    def __init__(
+        self,
+        *,
+        session: Any | None = None,
+        sandbox_backend: str = "docker",
+        lang: str = "python",
+        sync_paths: Iterable[str | Path] = (),
+        browser_backend: BrowserBackend | None = None,
+        session_kwargs: dict[str, Any] | None = None,
+        max_background_tasks: int = 16,
+    ) -> None:
+        super().__init__(browser_backend=browser_backend)
+        self._session = session
+        self._owns_session = session is None
+        self._sandbox_backend = sandbox_backend
+        self._lang = lang
+        self._sync_paths = tuple(sync_paths)
+        self._session_kwargs = dict(session_kwargs or {})
+        self._max_background_tasks = max_background_tasks
+        self._bound_workspace_dir: Path | None = None
+        self._command_executor: LLMSandboxCommandExecutor | None = None
+        self._workspace_adapter: LLMSandboxWorkspaceAdapter | None = None
+
+    @property
+    def workspace_dir(self) -> Path | None:
+        return self._bound_workspace_dir
+
+    def bind(self, workspace_dir: str | Path) -> LLMSandboxBackend:
+        self._bind_workspace(workspace_dir)
+        return self
+
+    def close(self) -> None:
+        if self._owns_session and self._session is not None:
+            self._session.close()
+
+    def __enter__(self) -> LLMSandboxBackend:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def resolve_command_executor(self, *, workspace_dir: str | Path):
+        self._bind_workspace(workspace_dir)
+        assert self._command_executor is not None
+        return self._command_executor
+
+    def resolve_workspace_adapter(self, *, workspace_dir: str | Path):
+        self._bind_workspace(workspace_dir)
+        assert self._workspace_adapter is not None
+        return self._workspace_adapter
+
+    def sync_to_runtime(self, *paths: str | Path) -> None:
+        workspace = self._require_workspace_binding()
+        session = self._ensure_session()
+        for host_path in self._resolve_sync_paths(paths, workspace):
+            if not host_path.exists():
+                raise FileNotFoundError(f"Host path not found: {host_path}")
+            session.execute_command(
+                command=f"mkdir -p {shlex.quote(str(host_path.parent))}",
+                workdir=None,
+            )
+            session.copy_to_runtime(str(host_path), str(host_path))
+
+    def sync_from_runtime(self, *paths: str | Path) -> None:
+        workspace = self._require_workspace_binding()
+        session = self._ensure_session()
+        for host_path in self._resolve_sync_paths(paths, workspace):
+            _copy_from_runtime_path(
+                session,
+                runtime_path=host_path,
+                local_path=host_path,
+            )
+
+    def _bind_workspace(self, workspace_dir: str | Path) -> None:
+        resolved_workspace = Path(workspace_dir).expanduser().resolve(strict=False)
+        if (
+            self._bound_workspace_dir is not None
+            and self._bound_workspace_dir != resolved_workspace
+        ):
+            raise RuntimeError(
+                "LLMSandboxBackend is already bound to "
+                f"{self._bound_workspace_dir}; create a new backend for {resolved_workspace}."
+            )
+        if self._bound_workspace_dir is not None:
+            return
+
+        session = self._ensure_session()
+        session.execute_command(
+            command=f"mkdir -p {shlex.quote(str(resolved_workspace))}",
+            workdir=None,
+        )
+        task_dir = f"/tmp/agnoclaw-llm-sandbox/{uuid4().hex[:12]}"
+        session.execute_command(command=f"mkdir -p {shlex.quote(task_dir)}", workdir=None)
+        self._bound_workspace_dir = resolved_workspace
+        self._command_executor = LLMSandboxCommandExecutor(
+            session=session,
+            workspace_dir=resolved_workspace,
+            task_dir=task_dir,
+            max_background_tasks=self._max_background_tasks,
+        )
+        self._workspace_adapter = LLMSandboxWorkspaceAdapter(
+            session=session,
+            workspace_dir=resolved_workspace,
+        )
+        if self._sync_paths:
+            self.sync_to_runtime(*self._sync_paths)
+
+    def _ensure_session(self) -> Any:
+        if self._session is None:
+            session_factory, sandbox_backend_enum = _load_llm_sandbox()
+            backend_value = self._coerce_sandbox_backend(sandbox_backend_enum)
+            self._session = session_factory(
+                backend=backend_value,
+                lang=self._lang,
+                **self._session_kwargs,
+            )
+        if not bool(getattr(self._session, "is_open", False)):
+            self._session.open()
+        return self._session
+
+    def _coerce_sandbox_backend(self, sandbox_backend_enum: Any) -> Any:
+        try:
+            return getattr(sandbox_backend_enum, str(self._sandbox_backend).upper())
+        except AttributeError as exc:
+            supported = ", ".join(member.name.lower() for member in sandbox_backend_enum)
+            raise ValueError(
+                f"Unsupported llm-sandbox backend '{self._sandbox_backend}'. "
+                f"Choose one of: {supported}."
+            ) from exc
+
+    def _require_workspace_binding(self) -> Path:
+        if self._bound_workspace_dir is None:
+            raise RuntimeError(
+                "LLMSandboxBackend must be bound to a workspace first. "
+                "Pass it to AgentHarness(..., backend=...) or call bind(workspace_dir)."
+            )
+        return self._bound_workspace_dir
+
+    @staticmethod
+    def _resolve_sync_paths(
+        paths: Iterable[str | Path],
+        workspace_dir: Path,
+    ) -> list[Path]:
+        resolved: list[Path] = []
+        for raw_path in paths:
+            candidate = Path(raw_path).expanduser()
+            if not candidate.is_absolute():
+                candidate = workspace_dir / candidate
+            resolved.append(candidate.resolve(strict=False))
+        return resolved
+
+
+def _copy_from_runtime_path(
+    session: Any,
+    *,
+    runtime_path: Path,
+    local_path: Path,
+) -> Path:
+    """Normalize llm-sandbox archive extraction for file and directory copies."""
+    session.copy_from_runtime(str(runtime_path), str(local_path))
+    nested_path = local_path / runtime_path.name
+    if local_path.exists() and not nested_path.exists():
+        return local_path
+
+    if not nested_path.exists():
+        raise FileNotFoundError(runtime_path)
+
+    local_path.mkdir(parents=True, exist_ok=True)
+    for child in nested_path.iterdir():
+        shutil.move(str(child), str(local_path / child.name))
+    nested_path.rmdir()
+    return local_path

--- a/src/agnoclaw/skills/__init__.py
+++ b/src/agnoclaw/skills/__init__.py
@@ -1,13 +1,29 @@
+from .backends import (
+    AutoApproveSkillInstallApprover,
+    CommandExecutorSkillRuntimeBackend,
+    InteractiveSkillInstallApprover,
+    LocalSkillRuntimeBackend,
+    SkillInstallApprover,
+    SkillInstallResult,
+    SkillRuntimeBackend,
+)
 from .hub import ClawHubClient, HubSkillDetail, HubSkillInfo
 from .loader import Skill, SkillMeta, load_skill_from_path
 from .registry import SkillRegistry
 
 __all__ = [
+    "AutoApproveSkillInstallApprover",
     "ClawHubClient",
+    "CommandExecutorSkillRuntimeBackend",
     "HubSkillDetail",
     "HubSkillInfo",
+    "InteractiveSkillInstallApprover",
+    "LocalSkillRuntimeBackend",
     "Skill",
+    "SkillInstallApprover",
+    "SkillInstallResult",
     "SkillMeta",
     "SkillRegistry",
+    "SkillRuntimeBackend",
     "load_skill_from_path",
 ]

--- a/src/agnoclaw/skills/backends.py
+++ b/src/agnoclaw/skills/backends.py
@@ -1,0 +1,315 @@
+"""Backend abstractions for skill runtime execution and installation."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from agnoclaw.tools.backends import CommandExecutor, LocalCommandExecutor
+
+if TYPE_CHECKING:
+    from .loader import Skill, SkillInstaller
+
+
+@dataclass(frozen=True)
+class SkillInstallResult:
+    """Normalized result for a skill installation attempt."""
+
+    success: bool
+    exit_code: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    message: str = ""
+
+
+class SkillRuntimeBackend(Protocol):
+    """Runtime backend for skill inline commands, probes, and installs."""
+
+    def run_inline_command(
+        self,
+        *,
+        command: str,
+        timeout_seconds: int = 10,
+        working_dir: str | None = None,
+    ) -> str:
+        ...
+
+    def has_binary(self, name: str) -> bool:
+        ...
+
+    def has_env_var(self, name: str) -> bool:
+        ...
+
+    def has_python_distribution(self, name: str) -> bool:
+        ...
+
+    def run_install(
+        self,
+        *,
+        installer_type: str,
+        package_spec: str,
+        timeout_seconds: int = 120,
+    ) -> SkillInstallResult:
+        ...
+
+
+class SkillInstallApprover(Protocol):
+    """Approval backend for skill dependency installs."""
+
+    def approve(self, skill: Skill, pending: list[tuple[SkillInstaller, str]]) -> bool:
+        ...
+
+
+def build_install_command(
+    installer_type: str,
+    package_spec: str,
+    *,
+    python_command: str | None = None,
+) -> list[str] | None:
+    """Build an install command for the local/command-executor runtime backends."""
+    if installer_type == "uv":
+        python_bin = python_command or sys.executable
+        return [python_bin, "-m", "uv", "pip", "install", package_spec]
+    if installer_type == "pip":
+        python_bin = python_command or sys.executable
+        return [python_bin, "-m", "pip", "install", "--quiet", package_spec]
+    if installer_type == "brew":
+        return ["brew", "install", package_spec]
+    if installer_type == "npm":
+        return ["npm", "install", "-g", package_spec]
+    if installer_type == "go":
+        return ["go", "install", package_spec]
+    return None
+
+
+class AutoApproveSkillInstallApprover:
+    """Install approver that always returns True."""
+
+    def approve(self, skill: Skill, pending: list[tuple[SkillInstaller, str]]) -> bool:
+        del skill, pending
+        return True
+
+
+class InteractiveSkillInstallApprover:
+    """Interactive terminal approver for skill installs."""
+
+    def approve(self, skill: Skill, pending: list[tuple[SkillInstaller, str]]) -> bool:
+        print(f"\nSkill '{skill.name}' requires the following installations:")
+        for installer, package_spec in pending:
+            print(f"  {installer.type}: {package_spec}")
+        print()
+        try:
+            answer = input("Proceed with installation? [y/N] ").strip().lower()
+            return answer in ("y", "yes")
+        except (EOFError, KeyboardInterrupt):
+            return False
+
+
+class LocalSkillRuntimeBackend:
+    """Host-local backend for skill execution, probes, and installs."""
+
+    def __init__(self, *, working_dir: str | Path | None = None) -> None:
+        self.working_dir = (
+            str(Path(working_dir).expanduser().resolve())
+            if working_dir is not None
+            else None
+        )
+
+    def run_inline_command(
+        self,
+        *,
+        command: str,
+        timeout_seconds: int = 10,
+        working_dir: str | None = None,
+    ) -> str:
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                cwd=working_dir or self.working_dir,
+            )
+            return result.stdout.strip()
+        except Exception as exc:
+            return f"[error running `{command}`: {exc}]"
+
+    def has_binary(self, name: str) -> bool:
+        return shutil.which(name) is not None
+
+    def has_env_var(self, name: str) -> bool:
+        return bool(os.environ.get(name))
+
+    def has_python_distribution(self, name: str) -> bool:
+        try:
+            from importlib.metadata import distribution
+
+            distribution(name)
+            return True
+        except Exception:
+            return False
+
+    def run_install(
+        self,
+        *,
+        installer_type: str,
+        package_spec: str,
+        timeout_seconds: int = 120,
+    ) -> SkillInstallResult:
+        command = build_install_command(installer_type, package_spec)
+        if command is None:
+            return SkillInstallResult(
+                success=False,
+                message=f"unknown installer type '{installer_type}'",
+            )
+
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                cwd=self.working_dir,
+            )
+            return SkillInstallResult(
+                success=result.returncode == 0,
+                exit_code=result.returncode,
+                stdout=result.stdout or "",
+                stderr=result.stderr or "",
+            )
+        except FileNotFoundError:
+            return SkillInstallResult(
+                success=False,
+                message=f"installer '{installer_type}' not found on PATH",
+            )
+        except subprocess.TimeoutExpired:
+            return SkillInstallResult(
+                success=False,
+                message=f"install timed out for {package_spec}",
+            )
+        except Exception as exc:
+            return SkillInstallResult(
+                success=False,
+                message=str(exc),
+            )
+
+
+class CommandExecutorSkillRuntimeBackend:
+    """Skill runtime backend that probes and executes through a CommandExecutor."""
+
+    _SAFE_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    def __init__(
+        self,
+        command_executor: CommandExecutor,
+        *,
+        working_dir: str | Path | None = None,
+        python_candidates: tuple[str, ...] = ("python3", "python"),
+    ) -> None:
+        self.command_executor = command_executor
+        self.working_dir = (
+            str(Path(working_dir).expanduser().resolve())
+            if working_dir is not None
+            else None
+        )
+        self.python_candidates = python_candidates
+
+    def run_inline_command(
+        self,
+        *,
+        command: str,
+        timeout_seconds: int = 10,
+        working_dir: str | None = None,
+    ) -> str:
+        try:
+            result = self.command_executor.run(
+                command=command,
+                workdir=working_dir or self.working_dir,
+                timeout_seconds=timeout_seconds,
+            )
+            return result.stdout.strip()
+        except Exception as exc:
+            return f"[error running `{command}`: {exc}]"
+
+    def has_binary(self, name: str) -> bool:
+        quoted = shlex.quote(name)
+        return self._run_probe(f"command -v {quoted} >/dev/null 2>&1")
+
+    def has_env_var(self, name: str) -> bool:
+        if not self._SAFE_ENV_NAME_RE.match(name):
+            return False
+        return self._run_probe(f'test -n "${{{name}+x}}"')
+
+    def has_python_distribution(self, name: str) -> bool:
+        python_bin = self._resolve_python_command()
+        if python_bin is None:
+            return False
+        quoted_name = name.replace("\\", "\\\\").replace("'", "\\'")
+        command = (
+            f"{python_bin} -c "
+            f"\"import importlib.metadata, sys; "
+            f"sys.exit(0 if importlib.metadata.distribution('{quoted_name}') else 1)\""
+        )
+        return self._run_probe(command)
+
+    def run_install(
+        self,
+        *,
+        installer_type: str,
+        package_spec: str,
+        timeout_seconds: int = 120,
+    ) -> SkillInstallResult:
+        python_bin = self._resolve_python_command() if installer_type in ("uv", "pip") else None
+        command = build_install_command(
+            installer_type,
+            package_spec,
+            python_command=python_bin,
+        )
+        if command is None:
+            return SkillInstallResult(
+                success=False,
+                message=f"unknown installer type '{installer_type}'",
+            )
+
+        command_str = " ".join(shlex.quote(part) for part in command)
+        try:
+            result = self.command_executor.run(
+                command=command_str,
+                workdir=self.working_dir,
+                timeout_seconds=timeout_seconds,
+            )
+            return SkillInstallResult(
+                success=result.exit_code == 0,
+                exit_code=result.exit_code,
+                stdout=result.stdout or "",
+                stderr=result.stderr or "",
+            )
+        except Exception as exc:
+            return SkillInstallResult(success=False, message=str(exc))
+
+    def _run_probe(self, command: str) -> bool:
+        try:
+            result = self.command_executor.run(
+                command=command,
+                workdir=self.working_dir,
+                timeout_seconds=10,
+            )
+            return result.exit_code == 0
+        except Exception:
+            return False
+
+    def _resolve_python_command(self) -> str | None:
+        for candidate in self.python_candidates:
+            if self.has_binary(candidate):
+                return candidate
+        if isinstance(self.command_executor, LocalCommandExecutor):
+            return sys.executable
+        return None

--- a/src/agnoclaw/skills/loader.py
+++ b/src/agnoclaw/skills/loader.py
@@ -53,12 +53,13 @@ from __future__ import annotations
 
 import logging
 import re
-import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
 import frontmatter
+
+from .backends import LocalSkillRuntimeBackend, SkillRuntimeBackend
 
 logger = logging.getLogger("agnoclaw.skills")
 
@@ -117,14 +118,21 @@ class Skill:
     def description(self) -> str:
         return self.meta.description
 
-    def render(self, arguments: str = "", *, allow_exec: bool = False) -> str:
+    def render(
+        self,
+        arguments: str = "",
+        *,
+        allow_exec: bool = False,
+        runtime_backend: SkillRuntimeBackend | None = None,
+        working_dir: str | Path | None = None,
+    ) -> str:
         """
         Render the skill content with argument substitution.
 
         Substitutes:
           $ARGUMENTS    → full arguments string
           $ARGUMENTS[N] → nth space-split argument
-          !`cmd`        → output of shell command (only if allow_exec=True)
+          !`cmd`        → output of shell command (only if allow_exec=True or backend provided)
 
         Security: Inline shell execution (!`cmd`) is disabled by default.
         Pass allow_exec=True only for trusted (builtin/local) skills.
@@ -132,8 +140,10 @@ class Skill:
 
         Args:
             arguments: Arguments to substitute into $ARGUMENTS placeholders.
-            allow_exec: If True, execute !`cmd` inline shell commands.
-                        If False (default), leave !`cmd` as literal text.
+            allow_exec: If True, execute !`cmd` inline shell commands using a local backend
+                        when no runtime backend is supplied.
+            runtime_backend: Optional backend for inline command execution.
+            working_dir: Optional working directory for inline command execution.
         """
         content = self.content
 
@@ -148,17 +158,23 @@ class Skill:
         content = content.replace("$ARGUMENTS", arguments)
 
         # Execute inline shell commands: !`cmd` — only if explicitly allowed
-        if allow_exec:
+        inline_backend = runtime_backend
+        if inline_backend is None and allow_exec:
+            inline_backend = LocalSkillRuntimeBackend(working_dir=working_dir)
+
+        if inline_backend is not None:
             def run_inline(m: re.Match) -> str:
                 cmd = m.group(1)
                 logger.debug("Skill '%s': executing inline command: %s", self.name, cmd)
-                try:
-                    result = subprocess.run(
-                        cmd, shell=True, capture_output=True, text=True, timeout=10
-                    )
-                    return result.stdout.strip()
-                except Exception as e:
-                    return f"[error running `{cmd}`: {e}]"
+                return inline_backend.run_inline_command(
+                    command=cmd,
+                    timeout_seconds=10,
+                    working_dir=(
+                        str(Path(working_dir).expanduser().resolve())
+                        if working_dir is not None
+                        else None
+                    ),
+                )
 
             content = re.sub(r"!`([^`]+)`", run_inline, content)
         else:

--- a/src/agnoclaw/skills/registry.py
+++ b/src/agnoclaw/skills/registry.py
@@ -37,15 +37,19 @@ Install support (metadata.openclaw.install):
 from __future__ import annotations
 
 import logging
-import os
 import platform
 import re
-import shutil
-import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
+from .backends import (
+    AutoApproveSkillInstallApprover,
+    InteractiveSkillInstallApprover,
+    LocalSkillRuntimeBackend,
+    SkillInstallApprover,
+    SkillRuntimeBackend,
+    build_install_command,
+)
 from .loader import Skill, SkillInstaller, load_skill_from_path
 
 logger = logging.getLogger("agnoclaw.skills")
@@ -102,12 +106,36 @@ class SkillRegistry:
         - "community": external sources — exec blocked, installs require approval + validation
     """
 
-    def __init__(self, workspace_skills_dir: Optional[Path] = None, *, auto_approve_installs: bool = False):
+    def __init__(
+        self,
+        workspace_skills_dir: Path | None = None,
+        *,
+        auto_approve_installs: bool = False,
+        runtime_backend: SkillRuntimeBackend | None = None,
+        install_approver: SkillInstallApprover | None = None,
+        working_dir: str | Path | None = None,
+    ):
         self._dirs: list[Path] = []
         self._cache: dict[str, Skill] = {}
-        self._bundled_dir: Optional[Path] = None
+        self._bundled_dir: Path | None = None
         self._local_dirs: list[Path] = []
         self._auto_approve_installs = auto_approve_installs
+        self._working_dir = (
+            Path(working_dir).expanduser().resolve()
+            if working_dir is not None
+            else None
+        )
+        self._runtime_backend = runtime_backend or LocalSkillRuntimeBackend(
+            working_dir=self._working_dir
+        )
+        self._install_approver = (
+            install_approver
+            or (
+                AutoApproveSkillInstallApprover()
+                if auto_approve_installs
+                else InteractiveSkillInstallApprover()
+            )
+        )
 
         # Build search path (highest → lowest priority)
         if workspace_skills_dir:
@@ -162,7 +190,7 @@ class SkillRegistry:
 
         return skills
 
-    def load_skill(self, name: str, arguments: str = "") -> Optional[str]:
+    def load_skill(self, name: str, arguments: str = "") -> str | None:
         """
         Load a skill by name and return its rendered content for injection.
 
@@ -190,8 +218,13 @@ class SkillRegistry:
         self._run_install(skill, trust)
 
         # Inline !`cmd` execution: only for builtin and local skills
-        allow_exec = trust in ("builtin", "local")
-        return skill.render(arguments, allow_exec=allow_exec)
+        runtime_backend = self._runtime_backend if trust in ("builtin", "local") else None
+        return skill.render(
+            arguments,
+            allow_exec=False,
+            runtime_backend=runtime_backend,
+            working_dir=self._working_dir,
+        )
 
     def list_skills(self) -> list[dict]:
         """
@@ -257,17 +290,20 @@ class SkillRegistry:
 
         # Required binaries (all must exist)
         for bin_name in skill.meta.requires_bins:
-            if not shutil.which(bin_name):
+            if not self._runtime_backend_for_call().has_binary(bin_name):
                 return False
 
         # anyBins (at least one must exist)
         if skill.meta.requires_any_bins:
-            if not any(shutil.which(b) for b in skill.meta.requires_any_bins):
+            if not any(
+                self._runtime_backend_for_call().has_binary(b)
+                for b in skill.meta.requires_any_bins
+            ):
                 return False
 
         # Required env vars
         for env_var in skill.meta.requires_env:
-            if not os.environ.get(env_var):
+            if not self._runtime_backend_for_call().has_env_var(env_var):
                 return False
 
         return True
@@ -344,7 +380,10 @@ class SkillRegistry:
 
             pkg = installer.package
             if installer.version:
-                pkg = f"{pkg}=={installer.version}" if installer.type in ("uv", "pip") else f"{pkg}@{installer.version}"
+                if installer.type in ("uv", "pip"):
+                    pkg = f"{pkg}=={installer.version}"
+                else:
+                    pkg = f"{pkg}@{installer.version}"
             pending.append((installer, pkg))
 
         if not pending:
@@ -358,51 +397,32 @@ class SkillRegistry:
 
         # Execute installs
         for installer, pkg in pending:
-            cmd = self._build_install_cmd(installer.type, pkg)
-            if cmd is None:
-                logger.warning("Skill '%s': unknown installer type '%s'", skill.name, installer.type)
-                continue
-
             logger.info("Skill '%s': installing %s (%s)", skill.name, pkg, installer.type)
-            try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=120,
-                )
-                if result.returncode != 0:
-                    logger.warning(
-                        "Skill '%s': install failed (exit %d): %s",
-                        skill.name,
-                        result.returncode,
-                        result.stderr[:200],
-                    )
-            except FileNotFoundError:
+            result = self._runtime_backend_for_call().run_install(
+                installer_type=installer.type,
+                package_spec=pkg,
+                timeout_seconds=120,
+            )
+            if not result.success:
+                detail = result.message or result.stderr[:200] or result.stdout[:200]
                 logger.warning(
-                    "Skill '%s': installer '%s' not found on PATH", skill.name, installer.type
+                    "Skill '%s': install failed (%s): %s",
+                    skill.name,
+                    result.exit_code if result.exit_code is not None else "no-exit-code",
+                    detail,
                 )
-            except subprocess.TimeoutExpired:
-                logger.warning("Skill '%s': install timed out for %s", skill.name, pkg)
-            except Exception as e:
-                logger.warning("Skill '%s': install error: %s", skill.name, e)
 
-    @staticmethod
-    def _prompt_install_approval(skill: Skill, pending: list[tuple[SkillInstaller, str]]) -> bool:
+    def _prompt_install_approval(
+        self,
+        skill: Skill,
+        pending: list[tuple[SkillInstaller, str]],
+    ) -> bool:
         """
         Display pending installs and prompt the user for approval.
 
         Returns True if the user approves, False otherwise.
         """
-        print(f"\nSkill '{skill.name}' requires the following installations:")
-        for installer, pkg in pending:
-            print(f"  {installer.type}: {pkg}")
-        print()
-        try:
-            answer = input("Proceed with installation? [y/N] ").strip().lower()
-            return answer in ("y", "yes")
-        except (EOFError, KeyboardInterrupt):
-            return False
+        return self._install_approver.approve(skill, pending)
 
     def _needs_install(self, installer: SkillInstaller) -> bool:
         """
@@ -413,43 +433,21 @@ class SkillRegistry:
         pkg = installer.package
 
         if itype in ("uv", "pip"):
-            # Use importlib.metadata for accurate installed-package detection.
-            # This handles cases where import name != package name
-            # (e.g. Pillow→PIL, beautifulsoup4→bs4, python-dateutil→dateutil).
             dist_name = pkg.split("[")[0].split("==")[0].split(">=")[0].split("<=")[0]
-            try:
-                from importlib.metadata import distribution
-                distribution(dist_name)
-                return False  # already installed
-            except Exception:
-                return True
+            return not self._runtime_backend_for_call().has_python_distribution(dist_name)
 
-        elif itype == "brew":
-            return shutil.which(pkg) is None
+        if itype in ("brew", "npm"):
+            return not self._runtime_backend_for_call().has_binary(pkg)
 
-        elif itype == "npm":
-            return shutil.which(pkg) is None
-
-        elif itype == "go":
-            # Go binaries land in $GOPATH/bin or $HOME/go/bin
-            return shutil.which(pkg.split("/")[-1]) is None
+        if itype == "go":
+            return not self._runtime_backend_for_call().has_binary(pkg.split("/")[-1])
 
         return True  # unknown type — try anyway
 
     @staticmethod
-    def _build_install_cmd(itype: str, pkg: str) -> Optional[list[str]]:
+    def _build_install_cmd(itype: str, pkg: str) -> list[str] | None:
         """Build the install command for the given installer type."""
-        if itype == "uv":
-            return [sys.executable, "-m", "uv", "pip", "install", pkg]
-        elif itype == "pip":
-            return [sys.executable, "-m", "pip", "install", "--quiet", pkg]
-        elif itype == "brew":
-            return ["brew", "install", pkg]
-        elif itype == "npm":
-            return ["npm", "install", "-g", pkg]
-        elif itype == "go":
-            return ["go", "install", pkg]
-        return None
+        return build_install_command(itype, pkg)
 
     # ── ClawHub integration ──────────────────────────────────────────────────
 
@@ -458,7 +456,7 @@ class SkillRegistry:
         name: str,
         hub_url: str = "https://clawhub.ai",
         cache_dir: str = "~/.agnoclaw/cache/hub",
-    ) -> Optional[Path]:
+    ) -> Path | None:
         """
         Download and install a skill from ClawHub to the workspace skills directory.
 
@@ -498,7 +496,7 @@ class SkillRegistry:
 
     # ── Internal helpers ───────────────────────────────────────────────────────
 
-    def _get_skill(self, name: str) -> Optional[Skill]:
+    def _get_skill(self, name: str) -> Skill | None:
         """Find a skill by name, checking cache first then scanning dirs."""
         if name in self._cache:
             return self._cache[name]
@@ -518,8 +516,15 @@ class SkillRegistry:
 
         return None
 
+    def _runtime_backend_for_call(self) -> SkillRuntimeBackend:
+        backend = getattr(self, "_runtime_backend", None)
+        if backend is not None:
+            return backend
+        working_dir = getattr(self, "_working_dir", None)
+        return LocalSkillRuntimeBackend(working_dir=working_dir)
+
     @staticmethod
-    def _find_bundled_skills_dir() -> Optional[Path]:
+    def _find_bundled_skills_dir() -> Path | None:
         """Find the bundled skills/ directory shipped with the package."""
         candidates = [
             Path(__file__).parent.parent.parent.parent / "skills",  # src layout

--- a/src/agnoclaw/teams.py
+++ b/src/agnoclaw/teams.py
@@ -19,18 +19,17 @@ Usage:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from agno.team import Team, TeamMode
 
-from .agent import AgentHarness, _resolve_model, _make_db
+from .agent import AgentHarness, _make_db, _resolve_model
+from .backends import RuntimeBackend
 from .config import HarnessConfig, get_config
+from .skills.backends import SkillInstallApprover
 from .tools import (
-    CommandExecutor,
     FilesToolkit,
     TodoToolkit,
     WebToolkit,
-    WorkspaceAdapter,
     make_bash_tool,
 )
 
@@ -47,8 +46,8 @@ def _build_member_agent(
     cfg: HarnessConfig,
     db,
     tools: list,
-    command_executor: CommandExecutor | None = None,
-    workspace_adapter: WorkspaceAdapter | None = None,
+    backend: RuntimeBackend | None = None,
+    skill_install_approver: SkillInstallApprover | None = None,
     learning=None,
     enable_learning: bool = False,
 ):
@@ -63,8 +62,8 @@ def _build_member_agent(
         instructions=role,
         enable_learning=enable_learning,
         debug=cfg.debug,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
     )
     harness._agent.role = role
     if learning is not None:
@@ -74,13 +73,13 @@ def _build_member_agent(
 
 
 def research_team(
-    model_id: Optional[str] = None,
-    provider: Optional[str] = None,
-    config: Optional[HarnessConfig] = None,
-    session_id: Optional[str] = None,
+    model_id: str | None = None,
+    provider: str | None = None,
+    config: HarnessConfig | None = None,
+    session_id: str | None = None,
     enable_learning: bool = False,
-    command_executor: CommandExecutor | None = None,
-    workspace_adapter: WorkspaceAdapter | None = None,
+    backend: RuntimeBackend | None = None,
+    skill_install_approver: SkillInstallApprover | None = None,
 ) -> Team:
     """
     A three-agent research team:
@@ -106,13 +105,16 @@ def research_team(
 
     researcher = _build_member_agent(
         name="Researcher",
-        role="Find factual information from multiple sources. Search broadly, read deeply. Always cite URLs.",
+        role=(
+            "Find factual information from multiple sources. Search broadly, "
+            "read deeply. Always cite URLs."
+        ),
         model=model,
         tools=[web, TodoToolkit()],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
         learning=_learning,
         enable_learning=enable_learning,
     )
@@ -127,8 +129,8 @@ def research_team(
         tools=[TodoToolkit()],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
         learning=_learning,
         enable_learning=enable_learning,
     )
@@ -144,8 +146,8 @@ def research_team(
         tools=[],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
         learning=_learning,
         enable_learning=enable_learning,
     )
@@ -171,13 +173,13 @@ def research_team(
 
 
 def code_team(
-    model_id: Optional[str] = None,
-    provider: Optional[str] = None,
-    config: Optional[HarnessConfig] = None,
-    session_id: Optional[str] = None,
+    model_id: str | None = None,
+    provider: str | None = None,
+    config: HarnessConfig | None = None,
+    session_id: str | None = None,
     enable_learning: bool = False,
-    command_executor: CommandExecutor | None = None,
-    workspace_adapter: WorkspaceAdapter | None = None,
+    backend: RuntimeBackend | None = None,
+    skill_install_approver: SkillInstallApprover | None = None,
 ) -> Team:
     """
     A three-agent software development team:
@@ -194,11 +196,14 @@ def code_team(
 
     model = _resolve_model(model_id, provider, cfg)
     workspace_dir = _tool_workspace_dir(cfg)
-    files = FilesToolkit(workspace_dir=workspace_dir, adapter=workspace_adapter)
+    resolved_backend = (backend or RuntimeBackend()).resolve(workspace_dir=workspace_dir)
+    resolved_command_executor = resolved_backend.command_executor
+    resolved_workspace_adapter = resolved_backend.workspace_adapter
+    files = FilesToolkit(workspace_dir=workspace_dir, adapter=resolved_workspace_adapter)
     bash = make_bash_tool(
         timeout=cfg.bash_timeout_seconds,
         workspace_dir=workspace_dir,
-        executor=command_executor,
+        executor=resolved_command_executor,
     )
 
     # Learning for code patterns — namespaced separately from research
@@ -218,8 +223,8 @@ def code_team(
         tools=[files, TodoToolkit()],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
         learning=_learning,
         enable_learning=enable_learning,
     )
@@ -235,8 +240,8 @@ def code_team(
         tools=[files, bash, TodoToolkit()],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
         learning=_learning,
         enable_learning=enable_learning,
     )
@@ -253,8 +258,8 @@ def code_team(
         tools=[files, bash],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
         learning=_learning,
         enable_learning=enable_learning,
     )
@@ -280,12 +285,12 @@ def code_team(
 
 
 def data_team(
-    model_id: Optional[str] = None,
-    provider: Optional[str] = None,
-    config: Optional[HarnessConfig] = None,
-    session_id: Optional[str] = None,
-    command_executor: CommandExecutor | None = None,
-    workspace_adapter: WorkspaceAdapter | None = None,
+    model_id: str | None = None,
+    provider: str | None = None,
+    config: HarnessConfig | None = None,
+    session_id: str | None = None,
+    backend: RuntimeBackend | None = None,
+    skill_install_approver: SkillInstallApprover | None = None,
 ) -> Team:
     """
     A two-agent data analysis team:
@@ -301,6 +306,7 @@ def data_team(
 
     model = _resolve_model(model_id, provider, cfg)
     workspace_dir = _tool_workspace_dir(cfg)
+    resolved_backend = (backend or RuntimeBackend()).resolve(workspace_dir=workspace_dir)
 
     fetcher = _build_member_agent(
         name="DataFetcher",
@@ -312,17 +318,20 @@ def data_team(
         model=model,
         tools=[
             WebToolkit(),
-            FilesToolkit(workspace_dir=workspace_dir, adapter=workspace_adapter),
+            FilesToolkit(
+                workspace_dir=workspace_dir,
+                adapter=resolved_backend.workspace_adapter,
+            ),
             make_bash_tool(
                 timeout=cfg.bash_timeout_seconds,
                 workspace_dir=workspace_dir,
-                executor=command_executor,
+                executor=resolved_backend.command_executor,
             ),
         ],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
     )
 
     analyst = _build_member_agent(
@@ -334,17 +343,20 @@ def data_team(
         ),
         model=model,
         tools=[
-            FilesToolkit(workspace_dir=workspace_dir, adapter=workspace_adapter),
+            FilesToolkit(
+                workspace_dir=workspace_dir,
+                adapter=resolved_backend.workspace_adapter,
+            ),
             make_bash_tool(
                 timeout=cfg.bash_timeout_seconds,
                 workspace_dir=workspace_dir,
-                executor=command_executor,
+                executor=resolved_backend.command_executor,
             ),
         ],
         db=db,
         cfg=cfg,
-        command_executor=command_executor,
-        workspace_adapter=workspace_adapter,
+        backend=backend,
+        skill_install_approver=skill_install_approver,
     )
 
     return Team(

--- a/src/agnoclaw/tools/__init__.py
+++ b/src/agnoclaw/tools/__init__.py
@@ -15,10 +15,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from agnoclaw.backends import RuntimeBackend
     from agnoclaw.config import HarnessConfig
 
 from .backends import CommandExecutor, LocalCommandExecutor, LocalWorkspaceAdapter, WorkspaceAdapter
 from .bash import BashToolkit, make_bash_tool
+from .browser_backends import BrowserBackend, LocalPlaywrightBrowserBackend
 from .files import FilesToolkit
 from .tasks import ProgressToolkit, SubagentDefinition, TodoToolkit, make_subagent_tool
 from .web import WebToolkit
@@ -28,10 +30,13 @@ logger = logging.getLogger("agnoclaw.tools")
 __all__ = [
     "make_bash_tool",
     "BashToolkit",
+    "BrowserBackend",
     "CommandExecutor",
     "FilesToolkit",
+    "LocalPlaywrightBrowserBackend",
     "LocalCommandExecutor",
     "LocalWorkspaceAdapter",
+    "RuntimeBackend",
     "WorkspaceAdapter",
     "WebToolkit",
     "TodoToolkit",
@@ -42,12 +47,19 @@ __all__ = [
 ]
 
 
+def __getattr__(name: str):
+    if name == "RuntimeBackend":
+        from agnoclaw.backends import RuntimeBackend
+
+        return RuntimeBackend
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def get_default_tools(
     config: HarnessConfig | None = None,
     subagents: dict[str, SubagentDefinition] | None = None,
     workspace_dir: str | Path | None = None,
-    command_executor: CommandExecutor | None = None,
-    workspace_adapter: WorkspaceAdapter | None = None,
+    backend: RuntimeBackend | None = None,
 ) -> list:
     """
     Build the default tool suite based on configuration.
@@ -59,23 +71,22 @@ def get_default_tools(
 
     Returns a list of tools and toolkits ready to pass to AgentHarness.
     """
+    from agnoclaw.backends import RuntimeBackend
     from agnoclaw.config import get_config
 
     cfg = config or get_config()
+
     tool_workspace_dir = (
         Path(workspace_dir).expanduser().resolve()
         if workspace_dir is not None
         else Path(cfg.workspace_dir).expanduser().resolve()
     )
+    effective_backend = backend or RuntimeBackend()
     tools = []
-
-    # File operations (always enabled)
-    resolved_workspace_adapter = workspace_adapter or LocalWorkspaceAdapter(
-        workspace_dir=tool_workspace_dir
-    )
-    resolved_command_executor = command_executor or LocalCommandExecutor(
-        workspace_dir=tool_workspace_dir
-    )
+    resolved_backend = effective_backend.resolve(workspace_dir=tool_workspace_dir)
+    resolved_workspace_adapter = resolved_backend.workspace_adapter
+    resolved_command_executor = resolved_backend.command_executor
+    resolved_browser_backend = resolved_backend.browser_backend
 
     tools.append(
         FilesToolkit(
@@ -123,17 +134,25 @@ def get_default_tools(
         subagents=subagents,
         workspace_dir=tool_workspace_dir,
         config=cfg,
-        command_executor=resolved_command_executor,
-        workspace_adapter=resolved_workspace_adapter,
+        backend=effective_backend,
     ))
 
     # ── Optional toolkits (conditional on config + importability) ─────────
 
     # Browser toolkit (requires agnoclaw[browser])
     if cfg.enable_browser:
+        if resolved_browser_backend is None and not effective_backend.uses_host_runtime():
+            raise ValueError(
+                "Browser tools are enabled, but the configured backend does not "
+                "provide browser support. "
+                "Pass a browser-capable backend or disable browser tools."
+            )
         try:
             from .browser import BrowserToolkit
-            tools.append(BrowserToolkit())
+            if resolved_browser_backend is None:
+                tools.append(BrowserToolkit())
+            else:
+                tools.append(BrowserToolkit(backend=resolved_browser_backend))
             logger.debug("Browser toolkit enabled")
         except ImportError:
             logger.debug("Browser toolkit requested but playwright not installed")

--- a/src/agnoclaw/tools/browser.py
+++ b/src/agnoclaw/tools/browser.py
@@ -1,66 +1,38 @@
 """
-Browser toolkit — Playwright-based browser automation for web interaction.
+Browser toolkit — browser/computer-use automation with pluggable backends.
 
 Matches OpenClaw's browser tool capabilities: navigate, click, type, screenshot,
 snapshot (accessible text), scroll, form fill.
-
-Optional extra: agnoclaw[browser] → playwright>=1.40.0
-
-The snapshot approach (structured text representation) is preferred over screenshots
-for LLM consumption — it's more token-efficient and gives the model actionable
-information about page structure.
-
-Usage:
-    from agnoclaw.tools.browser import BrowserToolkit
-
-    toolkit = BrowserToolkit()
-    # Tools: browser_navigate, browser_click, browser_type, browser_screenshot,
-    #        browser_snapshot, browser_scroll, browser_fill_form, browser_close
 """
 
 from __future__ import annotations
 
-import base64
-import logging
-
 from agno.tools.toolkit import Toolkit
 
-logger = logging.getLogger("agnoclaw.tools.browser")
+from .browser_backends import BrowserBackend, LocalPlaywrightBrowserBackend, check_playwright
 
 
-def _check_playwright():
-    """Check if playwright is importable."""
-    try:
-        import playwright  # noqa: F401
-        return True
-    except ImportError:
-        return False
+def _check_playwright() -> bool:
+    """Backward-compatible wrapper for playwright availability checks."""
+    return check_playwright()
 
 
 class BrowserToolkit(Toolkit):
-    """
-    Playwright-based browser automation toolkit.
-
-    Lazily initializes the browser on first use. Supports both headed and headless modes.
-
-    Args:
-        headless: Run browser in headless mode (default: True).
-        viewport_width: Browser viewport width in pixels.
-        viewport_height: Browser viewport height in pixels.
-    """
+    """Browser automation toolkit backed by a pluggable browser runtime."""
 
     def __init__(
         self,
         headless: bool = True,
         viewport_width: int = 1280,
         viewport_height: int = 720,
+        backend: BrowserBackend | None = None,
     ):
         super().__init__(name="browser")
-        self._headless = headless
-        self._viewport = {"width": viewport_width, "height": viewport_height}
-        self._playwright = None
-        self._browser = None
-        self._page = None
+        self.backend = backend or LocalPlaywrightBrowserBackend(
+            headless=headless,
+            viewport_width=viewport_width,
+            viewport_height=viewport_height,
+        )
 
         self.register(self.browser_navigate)
         self.register(self.browser_click)
@@ -71,252 +43,29 @@ class BrowserToolkit(Toolkit):
         self.register(self.browser_fill_form)
         self.register(self.browser_close)
 
-    def _ensure_page(self):
-        """Lazily initialize Playwright browser and page."""
-        if self._page is not None:
-            return
-
-        if not _check_playwright():
-            raise ImportError(
-                "Playwright is required for browser tools. "
-                "Install with: pip install agnoclaw[browser]"
-            )
-
-        from playwright.sync_api import sync_playwright
-
-        self._playwright = sync_playwright().start()
-        self._browser = self._playwright.chromium.launch(headless=self._headless)
-        context = self._browser.new_context(viewport=self._viewport)
-        self._page = context.new_page()
-        logger.debug("Browser initialized (headless=%s)", self._headless)
-
     def browser_navigate(self, url: str, wait_until: str = "domcontentloaded") -> str:
-        """
-        Navigate the browser to a URL.
-
-        Args:
-            url: The URL to navigate to (must include protocol, e.g. https://).
-            wait_until: Wait condition: 'domcontentloaded', 'load', or 'networkidle'.
-
-        Returns:
-            Page title and URL after navigation.
-        """
-        self._ensure_page()
-        try:
-            self._page.goto(url, wait_until=wait_until, timeout=30000)
-            title = self._page.title()
-            return f"Navigated to: {self._page.url}\nTitle: {title}"
-        except Exception as e:
-            return f"[error] Navigation failed: {e}"
+        return self.backend.navigate(url=url, wait_until=wait_until)
 
     def browser_click(self, selector: str) -> str:
-        """
-        Click an element on the page.
-
-        Args:
-            selector: CSS selector or text selector (e.g., 'button.submit', 'text=Sign In').
-
-        Returns:
-            Confirmation of the click action.
-        """
-        self._ensure_page()
-        try:
-            self._page.click(selector, timeout=10000)
-            return f"Clicked: {selector}"
-        except Exception as e:
-            return f"[error] Click failed on '{selector}': {e}"
+        return self.backend.click(selector=selector)
 
     def browser_type(self, selector: str, text: str) -> str:
-        """
-        Type text into an input element.
-
-        Args:
-            selector: CSS selector for the input element.
-            text: Text to type.
-
-        Returns:
-            Confirmation of the type action.
-        """
-        self._ensure_page()
-        try:
-            self._page.fill(selector, text, timeout=10000)
-            return f"Typed into '{selector}': {text[:50]}{'...' if len(text) > 50 else ''}"
-        except Exception as e:
-            return f"[error] Type failed on '{selector}': {e}"
+        return self.backend.type(selector=selector, text=text)
 
     def browser_screenshot(self, full_page: bool = False) -> str:
-        """
-        Take a screenshot of the current page.
-
-        Args:
-            full_page: If True, capture the full scrollable page. If False, just the viewport.
-
-        Returns:
-            Base64-encoded PNG screenshot.
-        """
-        self._ensure_page()
-        try:
-            screenshot_bytes = self._page.screenshot(full_page=full_page)
-            b64 = base64.b64encode(screenshot_bytes).decode("ascii")
-            return f"data:image/png;base64,{b64}"
-        except Exception as e:
-            return f"[error] Screenshot failed: {e}"
+        return self.backend.screenshot(full_page=full_page)
 
     def browser_snapshot(self) -> str:
-        """
-        Get a text representation of the current page — more token-efficient than screenshots.
-
-        Extracts visible text, links, forms, and buttons in a structured format
-        that LLMs can reason about effectively.
-
-        Returns:
-            Structured text representation of the page.
-        """
-        self._ensure_page()
-        try:
-            # Extract structured page content
-            snapshot = self._page.evaluate("""() => {
-                const result = [];
-                result.push('URL: ' + location.href);
-                result.push('Title: ' + document.title);
-                result.push('');
-
-                // Headings
-                const headings = document.querySelectorAll('h1, h2, h3');
-                if (headings.length > 0) {
-                    result.push('## Headings');
-                    headings.forEach(h => {
-                        const level = h.tagName.toLowerCase();
-                        result.push(`  ${level}: ${h.textContent.trim().substring(0, 200)}`);
-                    });
-                    result.push('');
-                }
-
-                // Links
-                const links = document.querySelectorAll('a[href]');
-                if (links.length > 0) {
-                    result.push('## Links');
-                    const seen = new Set();
-                    links.forEach(a => {
-                        const text = a.textContent.trim().substring(0, 100);
-                        const href = a.href;
-                        const key = text + href;
-                        if (text && !seen.has(key)) {
-                            seen.add(key);
-                            result.push(`  [${text}](${href})`);
-                        }
-                    });
-                    result.push('');
-                }
-
-                // Forms
-                const forms = document.querySelectorAll('form');
-                if (forms.length > 0) {
-                    result.push('## Forms');
-                    forms.forEach((form, i) => {
-                        result.push(`  Form ${i}: action=${form.action || '(none)'}`);
-                        form.querySelectorAll('input, select, textarea').forEach(input => {
-                            const type = input.type || input.tagName.toLowerCase();
-                            const name = input.name || input.id || '';
-                            const placeholder = input.placeholder || '';
-                            result.push(`    ${type}: name=${name} placeholder="${placeholder}"`);
-                        });
-                    });
-                    result.push('');
-                }
-
-                // Buttons
-                const buttons = document.querySelectorAll('button, [role="button"], input[type="submit"]');
-                if (buttons.length > 0) {
-                    result.push('## Buttons');
-                    buttons.forEach(b => {
-                        const text = b.textContent.trim().substring(0, 100) || b.value || '';
-                        if (text) result.push(`  [${text}]`);
-                    });
-                    result.push('');
-                }
-
-                // Main text content (truncated)
-                const main = document.querySelector('main, article, [role="main"]') || document.body;
-                const text = main.innerText.substring(0, 3000);
-                result.push('## Page Text (truncated)');
-                result.push(text);
-
-                return result.join('\\n');
-            }""")
-            return snapshot
-        except Exception as e:
-            return f"[error] Snapshot failed: {e}"
+        return self.backend.snapshot()
 
     def browser_scroll(self, direction: str = "down", amount: int = 500) -> str:
-        """
-        Scroll the page.
-
-        Args:
-            direction: Scroll direction: 'up' or 'down'.
-            amount: Pixels to scroll.
-
-        Returns:
-            Confirmation with new scroll position.
-        """
-        self._ensure_page()
-        try:
-            delta = amount if direction == "down" else -amount
-            self._page.mouse.wheel(0, delta)
-            scroll_y = self._page.evaluate("() => window.scrollY")
-            return f"Scrolled {direction} by {amount}px. Current position: {scroll_y}px"
-        except Exception as e:
-            return f"[error] Scroll failed: {e}"
+        return self.backend.scroll(direction=direction, amount=amount)
 
     def browser_fill_form(self, fields: str) -> str:
-        """
-        Fill multiple form fields at once.
-
-        Args:
-            fields: JSON object mapping CSS selectors to values.
-                    Example: {"#email": "user@example.com", "#password": "secret"}
-
-        Returns:
-            Confirmation of filled fields.
-        """
-        self._ensure_page()
-        import json
-
-        try:
-            field_map = json.loads(fields) if isinstance(fields, str) else fields
-        except (json.JSONDecodeError, TypeError):
-            return "[error] fields must be a JSON object mapping selectors to values"
-
-        results = []
-        for selector, value in field_map.items():
-            try:
-                self._page.fill(selector, str(value), timeout=5000)
-                results.append(f"  {selector}: OK")
-            except Exception as e:
-                results.append(f"  {selector}: FAILED ({e})")
-
-        return "Form fill results:\n" + "\n".join(results)
+        return self.backend.fill_form(fields=fields)
 
     def browser_close(self) -> str:
-        """
-        Close the browser and release resources.
-
-        Returns:
-            Confirmation that the browser was closed.
-        """
-        try:
-            if self._page:
-                self._page.close()
-                self._page = None
-            if self._browser:
-                self._browser.close()
-                self._browser = None
-            if self._playwright:
-                self._playwright.stop()
-                self._playwright = None
-            return "Browser closed."
-        except Exception as e:
-            return f"[error] Browser close failed: {e}"
+        return self.backend.close()
 
     def __del__(self):
         try:

--- a/src/agnoclaw/tools/browser_backends.py
+++ b/src/agnoclaw/tools/browser_backends.py
@@ -1,0 +1,231 @@
+"""Backend abstractions for browser/computer-use tooling."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Protocol
+
+logger = logging.getLogger("agnoclaw.tools.browser")
+
+
+def check_playwright() -> bool:
+    """Check if playwright is importable."""
+    try:
+        import playwright  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+class BrowserBackend(Protocol):
+    """Backend interface for browser/computer-use tool operations."""
+
+    def navigate(self, *, url: str, wait_until: str = "domcontentloaded") -> str:
+        ...
+
+    def click(self, *, selector: str) -> str:
+        ...
+
+    def type(self, *, selector: str, text: str) -> str:
+        ...
+
+    def screenshot(self, *, full_page: bool = False) -> str:
+        ...
+
+    def snapshot(self) -> str:
+        ...
+
+    def scroll(self, *, direction: str = "down", amount: int = 500) -> str:
+        ...
+
+    def fill_form(self, *, fields: str) -> str:
+        ...
+
+    def close(self) -> str:
+        ...
+
+
+class LocalPlaywrightBrowserBackend:
+    """Host-local Playwright backend preserving current browser toolkit behavior."""
+
+    def __init__(
+        self,
+        *,
+        headless: bool = True,
+        viewport_width: int = 1280,
+        viewport_height: int = 720,
+    ) -> None:
+        self._headless = headless
+        self._viewport = {"width": viewport_width, "height": viewport_height}
+        self._playwright = None
+        self._browser = None
+        self._page = None
+
+    def _ensure_page(self) -> None:
+        if self._page is not None:
+            return
+
+        if not check_playwright():
+            raise ImportError(
+                "Playwright is required for browser tools. "
+                "Install with: pip install agnoclaw[browser]"
+            )
+
+        from playwright.sync_api import sync_playwright
+
+        self._playwright = sync_playwright().start()
+        self._browser = self._playwright.chromium.launch(headless=self._headless)
+        context = self._browser.new_context(viewport=self._viewport)
+        self._page = context.new_page()
+        logger.debug("Browser initialized (headless=%s)", self._headless)
+
+    def navigate(self, *, url: str, wait_until: str = "domcontentloaded") -> str:
+        self._ensure_page()
+        try:
+            self._page.goto(url, wait_until=wait_until, timeout=30000)
+            title = self._page.title()
+            return f"Navigated to: {self._page.url}\nTitle: {title}"
+        except Exception as exc:
+            return f"[error] Navigation failed: {exc}"
+
+    def click(self, *, selector: str) -> str:
+        self._ensure_page()
+        try:
+            self._page.click(selector, timeout=10000)
+            return f"Clicked: {selector}"
+        except Exception as exc:
+            return f"[error] Click failed on '{selector}': {exc}"
+
+    def type(self, *, selector: str, text: str) -> str:
+        self._ensure_page()
+        try:
+            self._page.fill(selector, text, timeout=10000)
+            suffix = "..." if len(text) > 50 else ""
+            return f"Typed into '{selector}': {text[:50]}{suffix}"
+        except Exception as exc:
+            return f"[error] Type failed on '{selector}': {exc}"
+
+    def screenshot(self, *, full_page: bool = False) -> str:
+        self._ensure_page()
+        try:
+            screenshot_bytes = self._page.screenshot(full_page=full_page)
+            encoded = base64.b64encode(screenshot_bytes).decode("ascii")
+            return f"data:image/png;base64,{encoded}"
+        except Exception as exc:
+            return f"[error] Screenshot failed: {exc}"
+
+    def snapshot(self) -> str:
+        self._ensure_page()
+        try:
+            return self._page.evaluate(
+                """() => {
+                const result = [];
+                result.push('URL: ' + location.href);
+                result.push('Title: ' + document.title);
+                result.push('');
+
+                const headings = document.querySelectorAll('h1, h2, h3');
+                if (headings.length > 0) {
+                    result.push('## Headings');
+                    headings.forEach(h => {
+                        const level = h.tagName.toLowerCase();
+                        result.push(`  ${level}: ${h.textContent.trim().substring(0, 200)}`);
+                    });
+                    result.push('');
+                }
+
+                const links = document.querySelectorAll('a[href]');
+                if (links.length > 0) {
+                    result.push('## Links');
+                    const seen = new Set();
+                    links.forEach(a => {
+                        const text = a.textContent.trim().substring(0, 100);
+                        const href = a.href;
+                        const key = text + href;
+                        if (text && !seen.has(key)) {
+                            seen.add(key);
+                            result.push(`  [${text}](${href})`);
+                        }
+                    });
+                    result.push('');
+                }
+
+                const forms = document.querySelectorAll('form');
+                if (forms.length > 0) {
+                    result.push('## Forms');
+                    forms.forEach((form, i) => {
+                        result.push(`  Form ${i}: action=${form.action || '(none)'}`);
+                        form.querySelectorAll('input, select, textarea').forEach(input => {
+                            const type = input.type || input.tagName.toLowerCase();
+                            const name = input.name || input.id || '';
+                            const placeholder = input.placeholder || '';
+                            result.push(`    ${type}: name=${name} placeholder="${placeholder}"`);
+                        });
+                    });
+                    result.push('');
+                }
+
+                const buttons = document.querySelectorAll('button, [role="button"], input[type="submit"]');
+                if (buttons.length > 0) {
+                    result.push('## Buttons');
+                    buttons.forEach(b => {
+                        const text = b.textContent.trim().substring(0, 100) || b.value || '';
+                        if (text) result.push(`  [${text}]`);
+                    });
+                    result.push('');
+                }
+
+                const main = document.querySelector('main, article, [role="main"]') || document.body;
+                const text = main.innerText.substring(0, 3000);
+                result.push('## Page Text (truncated)');
+                result.push(text);
+
+                return result.join('\\n');
+            }"""
+            )
+        except Exception as exc:
+            return f"[error] Snapshot failed: {exc}"
+
+    def scroll(self, *, direction: str = "down", amount: int = 500) -> str:
+        self._ensure_page()
+        try:
+            delta = amount if direction == "down" else -amount
+            self._page.mouse.wheel(0, delta)
+            scroll_y = self._page.evaluate("() => window.scrollY")
+            return f"Scrolled {direction} by {amount}px. Current position: {scroll_y}px"
+        except Exception as exc:
+            return f"[error] Scroll failed: {exc}"
+
+    def fill_form(self, *, fields: str) -> str:
+        self._ensure_page()
+        try:
+            field_map = json.loads(fields) if isinstance(fields, str) else fields
+        except (json.JSONDecodeError, TypeError):
+            return "[error] fields must be a JSON object mapping selectors to values"
+
+        results = []
+        for selector, value in field_map.items():
+            try:
+                self._page.fill(selector, str(value), timeout=5000)
+                results.append(f"  {selector}: OK")
+            except Exception as exc:
+                results.append(f"  {selector}: FAILED ({exc})")
+        return "Form fill results:\n" + "\n".join(results)
+
+    def close(self) -> str:
+        try:
+            if self._page:
+                self._page.close()
+                self._page = None
+            if self._browser:
+                self._browser.close()
+                self._browser = None
+            if self._playwright:
+                self._playwright.stop()
+                self._playwright = None
+            return "Browser closed."
+        except Exception as exc:
+            return f"[error] Browser close failed: {exc}"

--- a/src/agnoclaw/tools/tasks.py
+++ b/src/agnoclaw/tools/tasks.py
@@ -28,10 +28,13 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from agno.tools import tool
 from agno.tools.toolkit import Toolkit
+
+if TYPE_CHECKING:
+    from agnoclaw.backends import RuntimeBackend
 
 logger = logging.getLogger("agnoclaw.tools")
 
@@ -109,7 +112,7 @@ class TodoToolkit(Toolkit):
         subject = self._todos[todo_id]["subject"]
         return f"Todo #{todo_id} '{subject}' → {status}"
 
-    def list_todos(self, filter_status: Optional[str] = None) -> str:
+    def list_todos(self, filter_status: str | None = None) -> str:
         """
         List all todos, optionally filtered by status.
 
@@ -359,23 +362,31 @@ class SubagentDefinition:
     description: str
     prompt: str = ""
     tools: list[str] = field(default_factory=lambda: ["all"])
-    model: Optional[str] = None
+    model: str | None = None
 
 
 # Default agent type instructions (used for ad-hoc agent_type= invocations)
 _TYPE_INSTRUCTIONS = {
-    "research": "You are a research specialist. Search the web, read URLs, and synthesize findings into a clear summary.",
+    "research": (
+        "You are a research specialist. Search the web, read URLs, and "
+        "synthesize findings into a clear summary."
+    ),
     "code": "You are a code specialist. Write clean, efficient code following best practices.",
-    "data": "You are a data analysis specialist. Analyze data, identify patterns, and present insights clearly.",
-    "general": "You are a capable assistant. Complete the assigned task thoroughly and efficiently.",
+    "data": (
+        "You are a data analysis specialist. Analyze data, identify patterns, "
+        "and present insights clearly."
+    ),
+    "general": (
+        "You are a capable assistant. Complete the assigned task thoroughly "
+        "and efficiently."
+    ),
 }
 
 
 def _build_subagent_tools(
     tool_names: list[str] | None,
     workspace_dir: str | Path | None = None,
-    command_executor=None,
-    workspace_adapter=None,
+    backend: RuntimeBackend | None = None,
 ) -> list:
     """Build tool instances for a subagent from tool name list."""
     agent_tools = []
@@ -383,6 +394,11 @@ def _build_subagent_tools(
     resolved_workspace = (
         Path(workspace_dir).expanduser().resolve()
         if workspace_dir is not None
+        else None
+    )
+    resolved_backend = (
+        backend.resolve(workspace_dir=resolved_workspace)
+        if backend is not None and resolved_workspace is not None
         else None
     )
     if "all" in names or "web" in names:
@@ -393,7 +409,11 @@ def _build_subagent_tools(
         agent_tools.append(
             FilesToolkit(
                 workspace_dir=resolved_workspace,
-                adapter=workspace_adapter,
+                adapter=(
+                    resolved_backend.workspace_adapter
+                    if resolved_backend is not None
+                    else None
+                ),
             )
         )
     if "all" in names or "bash" in names:
@@ -401,7 +421,11 @@ def _build_subagent_tools(
         agent_tools.append(
             make_bash_tool(
                 workspace_dir=resolved_workspace,
-                executor=command_executor,
+                executor=(
+                    resolved_backend.command_executor
+                    if resolved_backend is not None
+                    else None
+                ),
             )
         )
     return agent_tools
@@ -426,8 +450,7 @@ def _run_subagent(
     tool_names: list[str] | None = None,
     workspace_dir: str | Path | None = None,
     config=None,
-    command_executor=None,
-    workspace_adapter=None,
+    backend: RuntimeBackend | None = None,
 ) -> str:
     """Create and run an isolated subagent synchronously. Returns result string."""
     from agnoclaw.agent import AgentHarness, get_current_tool_runtime
@@ -446,8 +469,7 @@ def _run_subagent(
         tools=_build_subagent_tools(
             tool_names,
             workspace_dir=workspace_dir,
-            command_executor=command_executor,
-            workspace_adapter=workspace_adapter,
+            backend=backend,
         ),
         instructions=instructions,
         event_sink=(
@@ -465,6 +487,7 @@ def _run_subagent(
             if isinstance(parent_runtime, dict)
             else None
         ),
+        backend=backend,
     )
     response = subagent.run(task, context=subagent_context)
     content = response.content if response else "[no response]"
@@ -483,8 +506,7 @@ async def _arun_subagent(
     tool_names: list[str] | None = None,
     workspace_dir: str | Path | None = None,
     config=None,
-    command_executor=None,
-    workspace_adapter=None,
+    backend: RuntimeBackend | None = None,
 ) -> str:
     """Create and run an isolated subagent asynchronously. Returns result string."""
     from agnoclaw.agent import AgentHarness, get_current_tool_runtime
@@ -503,8 +525,7 @@ async def _arun_subagent(
         tools=_build_subagent_tools(
             tool_names,
             workspace_dir=workspace_dir,
-            command_executor=command_executor,
-            workspace_adapter=workspace_adapter,
+            backend=backend,
         ),
         instructions=instructions,
         event_sink=(
@@ -522,6 +543,7 @@ async def _arun_subagent(
             if isinstance(parent_runtime, dict)
             else None
         ),
+        backend=backend,
     )
 
     response = await subagent.arun(task, context=subagent_context)
@@ -538,8 +560,7 @@ def make_subagent_tool(
     subagents: dict[str, SubagentDefinition] | None = None,
     workspace_dir: str | Path | None = None,
     config=None,
-    command_executor=None,
-    workspace_adapter=None,
+    backend: RuntimeBackend | None = None,
 ):
     """
     Returns a SubagentTool function for spawning isolated sub-agents.
@@ -620,8 +641,7 @@ def make_subagent_tool(
                 tool_names,
                 workspace_dir=workspace_dir,
                 config=config,
-                command_executor=command_executor,
-                workspace_adapter=workspace_adapter,
+                backend=backend,
             )
 
         except Exception as e:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch
 
+from agnoclaw.backends import RuntimeBackend
+
 
 # ── _resolve_model tests ─────────────────────────────────────────────────────
 
@@ -314,12 +316,11 @@ def test_agent_harness_default_tools_use_constructor_workspace(tmp_path):
     assert Path(progress._project_dir) == Path(harness_workspace).resolve()
 
 
-def test_agent_harness_passes_custom_backends_to_default_tools(tmp_path):
+def test_agent_harness_passes_backend_to_default_tools(tmp_path):
     from agnoclaw.agent import AgentHarness
     from agnoclaw.config import HarnessConfig
 
-    executor = object()
-    adapter = object()
+    backend = RuntimeBackend(command_executor=object(), workspace_adapter=object())
 
     with patch("agnoclaw.agent.Agent", return_value=MagicMock()):
         with patch("agnoclaw.agent._make_db", return_value=MagicMock()):
@@ -327,12 +328,15 @@ def test_agent_harness_passes_custom_backends_to_default_tools(tmp_path):
                 AgentHarness(
                     workspace_dir=tmp_path,
                     config=HarnessConfig(),
-                    command_executor=executor,
-                    workspace_adapter=adapter,
+                    backend=backend,
                 )
 
-    assert mock_tools.call_args[1]["command_executor"] is executor
-    assert mock_tools.call_args[1]["workspace_adapter"] is adapter
+    assert mock_tools.call_args[1]["backend"] is backend
+
+
+def test_runtime_backend_requires_command_and_workspace_together():
+    with pytest.raises(ValueError, match="both command_executor and workspace_adapter"):
+        RuntimeBackend(command_executor=object())
 
 
 def test_agent_harness_instructions_param():

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,8 +1,34 @@
 """Tests for the browser toolkit."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+
+
+class FakeBrowserBackend:
+    def navigate(self, *, url: str, wait_until: str = "domcontentloaded") -> str:
+        return f"navigate:{url}:{wait_until}"
+
+    def click(self, *, selector: str) -> str:
+        return f"click:{selector}"
+
+    def type(self, *, selector: str, text: str) -> str:
+        return f"type:{selector}:{text}"
+
+    def screenshot(self, *, full_page: bool = False) -> str:
+        return f"screenshot:{full_page}"
+
+    def snapshot(self) -> str:
+        return "snapshot"
+
+    def scroll(self, *, direction: str = "down", amount: int = 500) -> str:
+        return f"scroll:{direction}:{amount}"
+
+    def fill_form(self, *, fields: str) -> str:
+        return f"fill:{fields}"
+
+    def close(self) -> str:
+        return "closed"
 
 
 def test_browser_toolkit_import():
@@ -44,10 +70,7 @@ def test_browser_navigate_requires_playwright():
 
     toolkit = BrowserToolkit()
     # If playwright is not installed, this should fail gracefully
-    with patch("agnoclaw.tools.browser._check_playwright", return_value=False):
-        toolkit._page = None
-        toolkit._playwright = None
-        toolkit._browser = None
+    with patch("agnoclaw.tools.browser_backends.check_playwright", return_value=False):
         with pytest.raises(ImportError, match="Playwright"):
             toolkit.browser_navigate("https://example.com")
 
@@ -61,28 +84,17 @@ def test_browser_close_when_not_initialized():
     assert "closed" in result.lower() or "Browser closed" in result
 
 
-def test_browser_scroll_values():
-    """Scroll should accept direction and amount parameters."""
+def test_browser_toolkit_delegates_to_custom_backend():
+    """BrowserToolkit should preserve tool names while delegating backend behavior."""
     from agnoclaw.tools.browser import BrowserToolkit
 
-    toolkit = BrowserToolkit()
-    # Mock the page to avoid needing a real browser
-    mock_page = MagicMock()
-    mock_page.mouse.wheel = MagicMock()
-    mock_page.evaluate.return_value = 500
-    toolkit._page = mock_page
+    toolkit = BrowserToolkit(backend=FakeBrowserBackend())
 
-    result = toolkit.browser_scroll("down", 300)
-    assert "500" in result  # scroll position
-    mock_page.mouse.wheel.assert_called_once_with(0, 300)
-
-
-def test_browser_fill_form_invalid_json():
-    """fill_form should handle invalid JSON gracefully."""
-    from agnoclaw.tools.browser import BrowserToolkit
-
-    toolkit = BrowserToolkit()
-    toolkit._page = MagicMock()
-
-    result = toolkit.browser_fill_form("not valid json")
-    assert "[error]" in result
+    assert toolkit.browser_navigate("https://example.com") == "navigate:https://example.com:domcontentloaded"
+    assert toolkit.browser_click("#submit") == "click:#submit"
+    assert toolkit.browser_type("#email", "hello") == "type:#email:hello"
+    assert toolkit.browser_screenshot(True) == "screenshot:True"
+    assert toolkit.browser_snapshot() == "snapshot"
+    assert toolkit.browser_scroll("down", 300) == "scroll:down:300"
+    assert toolkit.browser_fill_form("{\"#email\":\"a\"}") == 'fill:{"#email":"a"}'
+    assert toolkit.browser_close() == "closed"

--- a/tests/test_llm_sandbox_backend.py
+++ b/tests/test_llm_sandbox_backend.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from agnoclaw.integrations import LLMSandboxBackend
+from agnoclaw.tools.files import FilesToolkit
+
+
+@dataclass
+class _ConsoleOutput:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+class FakeLLMSandboxSession:
+    def __init__(self, runtime_root: Path) -> None:
+        self.runtime_root = runtime_root
+        self.is_open = False
+        self.calls: list[tuple[str, str | None]] = []
+        self._next_pid = 4000
+        self.background_tasks: dict[int, dict[str, object]] = {}
+
+    def open(self) -> None:
+        self.is_open = True
+
+    def close(self) -> None:
+        self.is_open = False
+
+    def execute_command(
+        self,
+        command: str,
+        workdir: str | None = None,
+        on_stdout=None,
+        on_stderr=None,
+    ) -> _ConsoleOutput:
+        del on_stdout, on_stderr
+        self.calls.append((command, workdir))
+
+        if "nohup sh -lc" in command:
+            match = re.search(
+                (
+                    r"> (?P<log>[^ ]+) 2>&1 < /dev/null & "
+                    r"pid=\$!; printf '%s' \"\$pid\" > (?P<pid_path>.+)$"
+                ),
+                command,
+            )
+            assert match is not None
+            log_path = self._unquote(match.group("log"))
+            pid_path = self._unquote(match.group("pid_path"))
+            exit_path = str(Path(log_path).with_suffix(".exit"))
+            pid = self._next_pid
+            self._next_pid += 1
+            self.background_tasks[pid] = {
+                "status": "running",
+                "exit_code": None,
+                "log_path": log_path,
+                "exit_path": exit_path,
+                "pid_path": pid_path,
+                "log_text": "",
+            }
+            self._runtime_path(pid_path).parent.mkdir(parents=True, exist_ok=True)
+            self._runtime_path(pid_path).write_text(str(pid), encoding="utf-8")
+            self._runtime_path(log_path).parent.mkdir(parents=True, exist_ok=True)
+            self._runtime_path(log_path).write_text("", encoding="utf-8")
+            return _ConsoleOutput(stdout=str(pid))
+
+        if command.startswith("mkdir -p "):
+            target = re.match(r"^mkdir -p '?(.*?)'?$", command)
+            assert target is not None
+            self._runtime_path(target.group(1)).mkdir(parents=True, exist_ok=True)
+            return _ConsoleOutput()
+
+        if command.startswith("if [ -f "):
+            exit_match = re.search(r"\[ -f (?P<exit_path>[^ ]+) \]", command)
+            pid_match = re.search(r"kill -0 (?P<pid>\d+)", command)
+            assert exit_match is not None
+            assert pid_match is not None
+            pid = int(pid_match.group("pid"))
+            task = self.background_tasks[pid]
+            if task["status"] == "running":
+                return _ConsoleOutput(stdout="status=running\n")
+            if task["status"] == "exited":
+                return _ConsoleOutput(
+                    stdout=f"status=exited\nexit_code={task['exit_code']}\n"
+                )
+            return _ConsoleOutput(stdout="status=terminated\n")
+
+        if command.startswith("if kill -0 "):
+            pid_match = re.search(r"if kill -0 (?P<pid>\d+)", command)
+            assert pid_match is not None
+            pid = int(pid_match.group("pid"))
+            task = self.background_tasks[pid]
+            if task["status"] == "running":
+                task["status"] = "terminated"
+                return _ConsoleOutput(stdout="terminated")
+            return _ConsoleOutput(stdout="not-running")
+
+        return _ConsoleOutput(stdout=f"ran:{command}:{workdir}")
+
+    def copy_to_runtime(self, src: str, dest: str) -> None:
+        src_path = Path(src)
+        dest_path = self._runtime_path(dest)
+        if src_path.is_dir():
+            if dest_path.exists():
+                shutil.rmtree(dest_path)
+            shutil.copytree(src_path, dest_path)
+            return
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src_path, dest_path)
+
+    def copy_from_runtime(self, src: str, dest: str) -> None:
+        src_path = self._runtime_path(src)
+        dest_path = Path(dest)
+        if not src_path.exists():
+            raise FileNotFoundError(src)
+        if src_path.is_dir():
+            dest_path.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src_path, dest_path / src_path.name)
+            return
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src_path, dest_path)
+
+    def mark_task_exited(self, pid: int, *, exit_code: int = 0, log_text: str = "") -> None:
+        task = self.background_tasks[pid]
+        task["status"] = "exited"
+        task["exit_code"] = exit_code
+        task["log_text"] = log_text
+        log_path = self._runtime_path(str(task["log_path"]))
+        exit_path = self._runtime_path(str(task["exit_path"]))
+        log_path.write_text(log_text, encoding="utf-8")
+        exit_path.write_text(str(exit_code), encoding="utf-8")
+
+    def _runtime_path(self, path: str) -> Path:
+        return self.runtime_root / Path(path).relative_to("/")
+
+    @staticmethod
+    def _unquote(text: str) -> str:
+        return text.strip("'")
+
+
+def test_llm_sandbox_backend_requires_binding_before_explicit_sync(tmp_path):
+    backend = LLMSandboxBackend(session=FakeLLMSandboxSession(tmp_path / "runtime"))
+
+    with pytest.raises(RuntimeError, match="must be bound to a workspace first"):
+        backend.sync_to_runtime("workspace/inputs")
+
+
+def test_llm_sandbox_backend_syncs_only_selected_paths(tmp_path):
+    workspace = tmp_path / "workspace"
+    inputs = workspace / "workspace" / "inputs"
+    inputs.mkdir(parents=True)
+    (inputs / "prompt.txt").write_text("hello", encoding="utf-8")
+    ignored = workspace / "workspace" / "private"
+    ignored.mkdir(parents=True)
+    (ignored / "secret.txt").write_text("nope", encoding="utf-8")
+
+    session = FakeLLMSandboxSession(tmp_path / "runtime")
+    backend = LLMSandboxBackend(session=session, sync_paths=["workspace/inputs"])
+
+    backend.bind(workspace)
+
+    runtime_inputs = session._runtime_path(str(inputs))
+    runtime_ignored = session._runtime_path(str(ignored))
+    assert (runtime_inputs / "prompt.txt").read_text(encoding="utf-8") == "hello"
+    assert not runtime_ignored.exists()
+
+
+def test_llm_sandbox_backend_rejects_rebinding_to_different_workspace(tmp_path):
+    session = FakeLLMSandboxSession(tmp_path / "runtime")
+    backend = LLMSandboxBackend(session=session)
+
+    backend.bind(tmp_path / "workspace-a")
+
+    with pytest.raises(RuntimeError, match="already bound"):
+        backend.bind(tmp_path / "workspace-b")
+
+
+def test_llm_sandbox_backend_files_stay_in_sandbox_until_pulled(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = FakeLLMSandboxSession(tmp_path / "runtime")
+    backend = LLMSandboxBackend(session=session).bind(workspace)
+    resolved = backend.resolve(workspace_dir=workspace)
+    files = FilesToolkit(adapter=resolved.workspace_adapter)
+
+    target = workspace / "workspace" / "outputs" / "result.txt"
+    result = files.write_file(str(target), "sandbox-only")
+
+    assert "Written" in result
+    assert not target.exists()
+    assert session._runtime_path(str(target)).read_text(encoding="utf-8") == "sandbox-only"
+
+    backend.sync_from_runtime("workspace/outputs")
+
+    assert target.read_text(encoding="utf-8") == "sandbox-only"
+
+
+def test_llm_sandbox_backend_command_execution_uses_bound_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = FakeLLMSandboxSession(tmp_path / "runtime")
+    backend = LLMSandboxBackend(session=session)
+
+    executor = backend.resolve(workspace_dir=workspace).command_executor
+    result = executor.run(command="pwd", workdir=None, timeout_seconds=5)
+
+    assert result.stdout == f"ran:pwd:{workspace}"
+
+
+def test_llm_sandbox_backend_background_command_lifecycle(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = FakeLLMSandboxSession(tmp_path / "runtime")
+    backend = LLMSandboxBackend(session=session)
+    executor = backend.resolve(workspace_dir=workspace).command_executor
+
+    handle = executor.start(command="sleep 10", workdir=None, description="test")
+    running = executor.output(task_id=handle.task_id)
+    assert running.status == "running"
+    assert running.pid == handle.pid
+
+    assert handle.pid is not None
+    session.mark_task_exited(handle.pid, exit_code=0, log_text="done\n")
+
+    exited = executor.output(task_id=handle.task_id)
+    assert exited.status == "exited"
+    assert exited.exit_code == 0
+    assert "done" in exited.output
+
+
+def test_llm_sandbox_backend_kill_updates_running_task(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = FakeLLMSandboxSession(tmp_path / "runtime")
+    backend = LLMSandboxBackend(session=session)
+    executor = backend.resolve(workspace_dir=workspace).command_executor
+
+    handle = executor.start(command="sleep 20", workdir=None, description="test")
+    message = executor.kill(task_id=handle.task_id)
+
+    assert "SIGTERM" in message
+    assert handle.pid is not None
+    assert session.background_tasks[handle.pid]["status"] == "terminated"

--- a/tests/test_llm_sandbox_live.py
+++ b/tests/test_llm_sandbox_live.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from agnoclaw.integrations import LLMSandboxBackend
+
+pytest.importorskip("llm_sandbox", reason="llm-sandbox extra is not installed")
+
+
+def _docker_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _docker_available(), reason="Docker daemon is not available"),
+]
+
+
+def test_llm_sandbox_backend_live_round_trip(tmp_path):
+    workspace = tmp_path / "workspace"
+    inputs_dir = workspace / "workspace" / "inputs"
+    outputs_dir = workspace / "workspace" / "outputs"
+    inputs_dir.mkdir(parents=True)
+    inputs_file = inputs_dir / "note.txt"
+    inputs_file.write_text("hello sandbox\n", encoding="utf-8")
+
+    backend = LLMSandboxBackend(sync_paths=["workspace/inputs"])
+    try:
+        backend.bind(workspace)
+        resolved = backend.resolve(workspace_dir=workspace)
+
+        command_result = resolved.command_executor.run(
+            command="cat workspace/inputs/note.txt",
+            workdir=None,
+            timeout_seconds=10,
+        )
+        assert command_result.exit_code == 0
+        assert command_result.stdout == "hello sandbox\n"
+
+        runtime_output = outputs_dir / "report.txt"
+        write_result = resolved.workspace_adapter.write_file(
+            str(runtime_output),
+            "generated in sandbox\n",
+        )
+        assert "Written" in write_result
+        assert not runtime_output.exists()
+
+        backend.sync_from_runtime("workspace/outputs")
+
+        assert runtime_output.exists()
+        assert runtime_output.read_text(encoding="utf-8") == "generated in sandbox\n"
+    finally:
+        backend.close()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 import pytest
 
+from agnoclaw.skills.backends import SkillInstallResult
 from agnoclaw.skills.loader import load_skill_from_path
 from agnoclaw.skills.registry import SkillRegistry, _validate_package_name
 
@@ -22,6 +23,41 @@ This is a test skill. Arguments: $ARGUMENTS
 
 First arg: $ARGUMENTS[0]
 """
+
+
+class FakeSkillRuntimeBackend:
+    def __init__(self):
+        self.calls = []
+
+    def run_inline_command(self, *, command: str, timeout_seconds: int = 10, working_dir: str | None = None) -> str:
+        self.calls.append(("inline", command, timeout_seconds, working_dir))
+        return f"inline:{command}:{working_dir}"
+
+    def has_binary(self, name: str) -> bool:
+        self.calls.append(("binary", name))
+        return name == "git"
+
+    def has_env_var(self, name: str) -> bool:
+        self.calls.append(("env", name))
+        return name == "MY_API_KEY"
+
+    def has_python_distribution(self, name: str) -> bool:
+        self.calls.append(("dist", name))
+        return name == "httpx"
+
+    def run_install(self, *, installer_type: str, package_spec: str, timeout_seconds: int = 120) -> SkillInstallResult:
+        self.calls.append(("install", installer_type, package_spec, timeout_seconds))
+        return SkillInstallResult(success=True, exit_code=0, stdout="ok")
+
+
+class FakeApprover:
+    def __init__(self, decision: bool = True):
+        self.decision = decision
+        self.calls = []
+
+    def approve(self, skill, pending):
+        self.calls.append((skill.name, pending))
+        return self.decision
 
 
 @pytest.fixture
@@ -79,6 +115,18 @@ def test_skill_registry_load(skill_dir):
     assert content is not None
     assert "Test Skill" in content
     assert "foo bar" in content
+
+
+def test_skill_registry_uses_custom_runtime_backend_for_inline_exec(exec_skill_dir):
+    registry = SkillRegistry(
+        workspace_skills_dir=exec_skill_dir,
+        runtime_backend=FakeSkillRuntimeBackend(),
+    )
+
+    content = registry.load_skill("exec-test")
+    assert content is not None
+    assert "inline:echo hello-from-shell" in content
+    assert "!`echo hello-from-shell`" not in content
 
 
 def test_skill_registry_missing(skill_dir):
@@ -302,6 +350,37 @@ def test_install_approval_declined(install_skill_dir):
     with patch.object(SkillRegistry, '_prompt_install_approval', return_value=False):
         content = registry.load_skill("install-test")
     assert content is not None  # skill still loads, install just skipped
+
+
+def test_install_runtime_backend_and_approver_are_used(install_skill_dir):
+    runtime_backend = FakeSkillRuntimeBackend()
+    runtime_backend.has_python_distribution = lambda name: False
+    approver = FakeApprover(decision=True)
+    registry = SkillRegistry(
+        workspace_skills_dir=install_skill_dir,
+        runtime_backend=runtime_backend,
+        install_approver=approver,
+    )
+
+    content = registry.load_skill("install-test")
+
+    assert content is not None
+    assert approver.calls
+    assert ("install", "pip", "httpx", 120) in runtime_backend.calls
+
+
+def test_install_runtime_backend_skips_install_when_dependency_present(install_skill_dir):
+    runtime_backend = FakeSkillRuntimeBackend()
+    registry = SkillRegistry(
+        workspace_skills_dir=install_skill_dir,
+        runtime_backend=runtime_backend,
+        auto_approve_installs=True,
+    )
+
+    content = registry.load_skill("install-test")
+
+    assert content is not None
+    assert not any(call[0] == "install" for call in runtime_backend.calls)
 
 
 # ── Security: community skill inline exec blocked ─────────────────────────────

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from agnoclaw.backends import RuntimeBackend
 from agnoclaw.config import HarnessConfig
 from agnoclaw.tools.backends import CommandResult
 
@@ -254,16 +255,16 @@ def test_data_team_uses_config_workspace_for_file_and_bash_tools(tmp_path):
     assert fetcher_files.functions["read_file"].pre_hook is not None
 
 
-def test_code_team_uses_custom_backends(tmp_path):
+def test_code_team_uses_backend(tmp_path):
     from agnoclaw.teams import code_team
     from agnoclaw.tools.files import FilesToolkit
 
     adapter = FakeWorkspaceAdapter(workspace_dir=tmp_path)
     executor = FakeCommandExecutor(workspace_dir=tmp_path)
+    backend = RuntimeBackend(command_executor=executor, workspace_adapter=adapter)
     team = code_team(
         config=HarnessConfig(workspace_dir=str(tmp_path)),
-        workspace_adapter=adapter,
-        command_executor=executor,
+        backend=backend,
     )
 
     implementer_files = next(t for t in team.members[1].tools if isinstance(t, FilesToolkit))
@@ -274,16 +275,16 @@ def test_code_team_uses_custom_backends(tmp_path):
     assert implementer_bash.entrypoint("echo hi") == "team-executor-run:echo hi:None:120"
 
 
-def test_data_team_uses_custom_backends(tmp_path):
+def test_data_team_uses_backend(tmp_path):
     from agnoclaw.teams import data_team
     from agnoclaw.tools.files import FilesToolkit
 
     adapter = FakeWorkspaceAdapter(workspace_dir=tmp_path)
     executor = FakeCommandExecutor(workspace_dir=tmp_path)
+    backend = RuntimeBackend(command_executor=executor, workspace_adapter=adapter)
     team = data_team(
         config=HarnessConfig(workspace_dir=str(tmp_path)),
-        workspace_adapter=adapter,
-        command_executor=executor,
+        backend=backend,
     )
 
     fetcher_files = next(t for t in team.members[0].tools if isinstance(t, FilesToolkit))
@@ -291,3 +292,23 @@ def test_data_team_uses_custom_backends(tmp_path):
 
     assert fetcher_files.adapter is adapter
     assert fetcher_bash.entrypoint("echo hi") == "team-executor-run:echo hi:None:120"
+
+
+def test_code_team_uses_runtime_backend(tmp_path):
+    from agnoclaw.teams import code_team
+    from agnoclaw.tools.files import FilesToolkit
+
+    backend = RuntimeBackend(
+        command_executor=FakeCommandExecutor(workspace_dir=tmp_path),
+        workspace_adapter=FakeWorkspaceAdapter(workspace_dir=tmp_path),
+    )
+    team = code_team(
+        config=HarnessConfig(workspace_dir=str(tmp_path)),
+        backend=backend,
+    )
+
+    implementer_files = next(t for t in team.members[1].tools if isinstance(t, FilesToolkit))
+    implementer_bash = team.members[1].tools[1]
+
+    assert implementer_files.adapter is backend.resolve(workspace_dir=tmp_path).workspace_adapter
+    assert implementer_bash.entrypoint("echo hi") == "team-executor-run:echo hi:None:120"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from agnoclaw.backends import RuntimeBackend
+from agnoclaw.skills.backends import SkillInstallResult
 from agnoclaw.tools.backends import (
     BackgroundCommandHandle,
     BackgroundCommandOutput,
@@ -100,6 +102,82 @@ class FakeCommandExecutor:
     def kill(self, *, task_id: str, force: bool = False) -> str:
         self.calls.append(("kill", task_id, force))
         return f"executor-kill:{task_id}:{force}"
+
+
+class FakeSkillRuntimeBackend:
+    def __init__(self):
+        self.calls = []
+
+    def run_inline_command(self, *, command: str, timeout_seconds: int = 10, working_dir: str | None = None) -> str:
+        self.calls.append(("inline", command, timeout_seconds, working_dir))
+        return f"skill-inline:{command}"
+
+    def has_binary(self, name: str) -> bool:
+        self.calls.append(("binary", name))
+        return True
+
+    def has_env_var(self, name: str) -> bool:
+        self.calls.append(("env", name))
+        return True
+
+    def has_python_distribution(self, name: str) -> bool:
+        self.calls.append(("dist", name))
+        return True
+
+    def run_install(self, *, installer_type: str, package_spec: str, timeout_seconds: int = 120) -> SkillInstallResult:
+        self.calls.append(("install", installer_type, package_spec, timeout_seconds))
+        return SkillInstallResult(success=True, exit_code=0)
+
+
+class FakeBrowserBackend:
+    def navigate(self, *, url: str, wait_until: str = "domcontentloaded") -> str:
+        return f"browser:{url}:{wait_until}"
+
+    def click(self, *, selector: str) -> str:
+        return f"click:{selector}"
+
+    def type(self, *, selector: str, text: str) -> str:
+        return f"type:{selector}:{text}"
+
+    def screenshot(self, *, full_page: bool = False) -> str:
+        return f"screenshot:{full_page}"
+
+    def snapshot(self) -> str:
+        return "snapshot"
+
+    def scroll(self, *, direction: str = "down", amount: int = 500) -> str:
+        return f"scroll:{direction}:{amount}"
+
+    def fill_form(self, *, fields: str) -> str:
+        return f"fill:{fields}"
+
+    def close(self) -> str:
+        return "closed"
+
+
+class FakeRuntimeBackend(RuntimeBackend):
+    def __init__(
+        self,
+        *,
+        command_executor=None,
+        workspace_adapter=None,
+        browser_backend=None,
+        skill_runtime=None,
+    ):
+        super().__init__(
+            command_executor=command_executor,
+            workspace_adapter=workspace_adapter,
+            browser_backend=browser_backend,
+        )
+        self._skill_runtime = skill_runtime
+
+    def resolve_skill_runtime(self, *, workspace_dir: str | Path, command_executor=None):
+        if self._skill_runtime is not None:
+            return self._skill_runtime
+        return super().resolve_skill_runtime(
+            workspace_dir=workspace_dir,
+            command_executor=command_executor,
+        )
 
 
 # ── FilesToolkit tests ────────────────────────────────────────────────────
@@ -694,7 +772,7 @@ def test_get_default_tools_workspace_override_applies_to_files_and_progress(tmp_
     assert Path(progress._project_dir) == (tmp_path / "embedder-ws").resolve()
 
 
-def test_get_default_tools_uses_custom_backends(tmp_path):
+def test_get_default_tools_uses_custom_backend(tmp_path):
     from agnoclaw.config import HarnessConfig
     from agnoclaw.tools import get_default_tools
     from agnoclaw.tools.files import FilesToolkit
@@ -702,12 +780,12 @@ def test_get_default_tools_uses_custom_backends(tmp_path):
     cfg = HarnessConfig(workspace_dir="~/.agnoclaw/workspace")
     adapter = FakeWorkspaceAdapter(workspace_dir=tmp_path)
     executor = FakeCommandExecutor(workspace_dir=tmp_path)
+    backend = RuntimeBackend(command_executor=executor, workspace_adapter=adapter)
 
     tools = get_default_tools(
         cfg,
         workspace_dir=tmp_path,
-        workspace_adapter=adapter,
-        command_executor=executor,
+        backend=backend,
     )
 
     files = next(t for t in tools if isinstance(t, FilesToolkit))
@@ -716,6 +794,67 @@ def test_get_default_tools_uses_custom_backends(tmp_path):
     assert files.adapter is adapter
     assert files.read_file("/tmp/demo.txt") == "adapter-read:/tmp/demo.txt:0:2000"
     assert bash.entrypoint("echo hi") == "executor-run:echo hi:None:120"
+
+
+def test_get_default_tools_uses_runtime_backend(tmp_path):
+    from agnoclaw.config import HarnessConfig
+    from agnoclaw.tools import get_default_tools
+    from agnoclaw.tools.files import FilesToolkit
+
+    adapter = FakeWorkspaceAdapter(workspace_dir=tmp_path)
+    executor = FakeCommandExecutor(workspace_dir=tmp_path)
+    skill_runtime = FakeSkillRuntimeBackend()
+    browser_backend = FakeBrowserBackend()
+    backend = FakeRuntimeBackend(
+        command_executor=executor,
+        workspace_adapter=adapter,
+        skill_runtime=skill_runtime,
+        browser_backend=browser_backend,
+    )
+
+    tools = get_default_tools(
+        HarnessConfig(enable_browser=True),
+        workspace_dir=tmp_path,
+        backend=backend,
+    )
+
+    files = next(t for t in tools if isinstance(t, FilesToolkit))
+    bash = next(t for t in tools if getattr(t, "name", None) == "bash")
+    browser = next(t for t in tools if getattr(t, "name", None) == "browser")
+
+    assert files.adapter is adapter
+    assert bash.entrypoint("echo hi") == "executor-run:echo hi:None:120"
+    assert browser.browser_snapshot() == "snapshot"
+
+
+def test_runtime_backend_requires_command_and_workspace_together(tmp_path):
+    with pytest.raises(ValueError, match="both command_executor and workspace_adapter"):
+        RuntimeBackend(command_executor=FakeCommandExecutor(workspace_dir=tmp_path))
+
+
+def test_custom_runtime_backend_does_not_silently_fallback_to_host(tmp_path):
+    class IncompleteRuntimeBackend(RuntimeBackend):
+        pass
+
+    with pytest.raises(RuntimeError, match="must provide command execution"):
+        IncompleteRuntimeBackend().resolve(workspace_dir=tmp_path)
+
+
+def test_get_default_tools_rejects_custom_backend_without_browser_support(tmp_path):
+    from agnoclaw.config import HarnessConfig
+    from agnoclaw.tools import get_default_tools
+
+    backend = RuntimeBackend(
+        command_executor=FakeCommandExecutor(workspace_dir=tmp_path),
+        workspace_adapter=FakeWorkspaceAdapter(workspace_dir=tmp_path),
+    )
+
+    with pytest.raises(ValueError, match="does not provide browser support"):
+        get_default_tools(
+            HarnessConfig(enable_browser=True),
+            workspace_dir=tmp_path,
+            backend=backend,
+        )
 
 
 def test_web_toolkit_both_enabled_by_default():
@@ -1094,12 +1233,12 @@ def test_build_subagent_tools_uses_custom_backends(tmp_path):
 
     adapter = FakeWorkspaceAdapter(workspace_dir=tmp_path)
     executor = FakeCommandExecutor(workspace_dir=tmp_path)
+    backend = RuntimeBackend(command_executor=executor, workspace_adapter=adapter)
 
     tools = _build_subagent_tools(
         ["files", "bash"],
         workspace_dir=tmp_path,
-        workspace_adapter=adapter,
-        command_executor=executor,
+        backend=backend,
     )
     files = next(t for t in tools if isinstance(t, FilesToolkit))
     bash = next(t for t in tools if getattr(t, "name", None) == "bash")
@@ -1216,14 +1355,34 @@ def test_get_default_tools_passes_custom_backends_to_subagent_tool(tmp_path):
     cfg = HarnessConfig()
     adapter = FakeWorkspaceAdapter(workspace_dir=tmp_path)
     executor = FakeCommandExecutor(workspace_dir=tmp_path)
+    backend = RuntimeBackend(command_executor=executor, workspace_adapter=adapter)
 
     with patch("agnoclaw.tools.make_subagent_tool") as mock_make:
         mock_make.return_value = MagicMock()
         get_default_tools(
             cfg,
             workspace_dir=tmp_path,
-            workspace_adapter=adapter,
-            command_executor=executor,
+            backend=backend,
         )
-        assert mock_make.call_args[1]["workspace_adapter"] is adapter
-        assert mock_make.call_args[1]["command_executor"] is executor
+        assert mock_make.call_args[1]["backend"] is backend
+
+
+def test_get_default_tools_passes_skill_runtime_backend_to_subagent_tool(tmp_path):
+    from agnoclaw.config import HarnessConfig
+    from agnoclaw.tools import get_default_tools
+
+    cfg = HarnessConfig()
+    backend = FakeRuntimeBackend(
+        command_executor=FakeCommandExecutor(workspace_dir=tmp_path),
+        workspace_adapter=FakeWorkspaceAdapter(workspace_dir=tmp_path),
+        skill_runtime=FakeSkillRuntimeBackend(),
+    )
+
+    with patch("agnoclaw.tools.make_subagent_tool") as mock_make:
+        mock_make.return_value = MagicMock()
+        get_default_tools(
+            cfg,
+            workspace_dir=tmp_path,
+            backend=backend,
+        )
+        assert mock_make.call_args[1]["backend"] is backend

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "agnoclaw"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },
@@ -80,6 +80,9 @@ full = [
     { name = "prompt-toolkit" },
     { name = "textual" },
 ]
+llm-sandbox = [
+    { name = "llm-sandbox", extra = ["docker"] },
+]
 local = [
     { name = "ollama" },
     { name = "openai" },
@@ -125,6 +128,7 @@ requires-dist = [
     { name = "groq", marker = "extra == 'all-models'", specifier = ">=0.11.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "lancedb", marker = "extra == 'rag'", specifier = ">=0.4.0" },
+    { name = "llm-sandbox", extras = ["docker"], marker = "extra == 'llm-sandbox'", specifier = ">=0.3.31" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "nbformat", marker = "extra == 'dev'", specifier = ">=5.9.0" },
@@ -154,7 +158,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.85.0" },
     { name = "textual-dev", marker = "extra == 'dev'", specifier = ">=1.0.0" },
 ]
-provides-extras = ["cli", "tui", "full", "postgres", "local", "all-models", "browser", "mcp", "media", "rag", "notebook", "dev"]
+provides-extras = ["cli", "tui", "full", "postgres", "local", "all-models", "browser", "llm-sandbox", "mcp", "media", "rag", "notebook", "dev"]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -643,6 +647,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1332,6 +1350,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "llm-sandbox"
+version = "0.3.37"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/96/fa676c1551ed96a6d4814c1a5ad8561d723be7344e03bc293d9ee53b3db7/llm_sandbox-0.3.37.tar.gz", hash = "sha256:bec2d2d2b6eb5311fd70e4aa6a21e60c3c7e8dee36f89aac47a1fd072485adc6", size = 605861, upload-time = "2026-03-02T06:45:28.168Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/d0/63e594b6ae23ed4b63d57d5e442308f9c70f61f16002da4c41a4436939a6/llm_sandbox-0.3.37-py3-none-any.whl", hash = "sha256:8c0a01a79e8db45bcf709a349aee2983cc3ed22d56f3110ec9fbcdeef43c78f3", size = 106853, upload-time = "2026-03-02T06:45:26.766Z" },
+]
+
+[package.optional-dependencies]
+docker = [
+    { name = "docker" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n- unify shell, files, skills, subagents, teams, and browser under a single runtime backend\n- add optional first-party Docker-first LLMSandboxBackend with explicit sync semantics\n- update docs, examples, tests, and add a live Docker round-trip integration test\n\n## Verification\n- uv run --extra dev pytest tests/test_llm_sandbox_backend.py tests/test_tools.py tests/test_agent.py tests/test_teams.py tests/test_skills.py tests/test_browser.py tests/test_runtime_contracts.py -q\n- uv run --extra dev --extra llm-sandbox pytest tests/test_llm_sandbox_live.py -q\n- python3 -m compileall src/agnoclaw\n