### PR TITLE
v0.7.4 fix: close sqlite history leaks and support structured output config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.7.3"
+version = "0.7.4"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -88,4 +88,4 @@ __all__ = [
     "Workspace",
 ]
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -61,6 +61,7 @@ import shlex
 import shutil
 import tempfile
 import warnings
+import weakref
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from contextvars import ContextVar
 from pathlib import Path
@@ -299,6 +300,9 @@ class AgentHarness:
         max_context_tokens: Max context window tokens. When set, enables automatic
                            context budget monitoring with warnings at 85% and
                            auto-compaction at 95%.
+        output_schema: Optional default structured-output schema for all runs.
+        parser_model: Optional secondary model used to parse structured output.
+        parse_response: Whether structured outputs should be parsed into objects.
         provider: Provider name — only needed when model is not in "provider:model_id"
                   format. Accepts "anthropic", "openai", "ollama", "groq", "google",
                   "aws"/"bedrock", "mistral", "xai"/"grok", "deepseek", "litellm".
@@ -342,6 +346,15 @@ class AgentHarness:
         num_history_messages: int | None = None,
         max_tool_calls_from_history: int | None = None,
         max_context_tokens: int | None = None,
+        # Structured output / response parsing
+        output_schema: type | dict[str, Any] | None = None,
+        parser_model: Any | None = None,
+        parser_model_prompt: str | None = None,
+        output_model: Any | None = None,
+        output_model_prompt: str | None = None,
+        parse_response: bool = True,
+        structured_outputs: bool | None = None,
+        use_json_mode: bool = False,
         # v0.2 runtime contracts
         event_sink: EventSink | None = None,
         event_sink_mode: str | None = None,
@@ -391,6 +404,7 @@ class AgentHarness:
         self._on_compaction = on_compaction
         self._on_session_end = on_session_end
         self._session_metadata = dict(session_metadata or {})
+        self._closed = False
 
         # Runtime extension contracts
         self._event_sink: EventSink = event_sink or NullEventSink()
@@ -563,7 +577,15 @@ class AgentHarness:
         system_prompt = self._build_system_prompt(session_id=session_id)
 
         # Storage backend
-        db = db or _make_db(self.config)
+        provided_db = db
+        db = provided_db if provided_db is not None else _make_db(self.config)
+        self._owns_storage = provided_db is None
+        self._finalizer = weakref.finalize(
+            self,
+            AgentHarness._finalize_resources,
+            db if self._owns_storage else None,
+            str(self.sandbox_dir) if sandbox_dir is None else None,
+        )
 
         # ── Memory: LearningMachine (unified per-user + institutional) ──────
         # LearningMachine handles both per-user memory (user_profile,
@@ -619,6 +641,14 @@ class AgentHarness:
             num_history_runs=num_history_runs or self.config.session_history_runs,
             num_history_messages=num_history_messages,
             max_tool_calls_from_history=max_tool_calls_from_history,
+            output_schema=output_schema,
+            parser_model=parser_model,
+            parser_model_prompt=parser_model_prompt,
+            output_model=output_model,
+            output_model_prompt=output_model_prompt,
+            parse_response=parse_response,
+            structured_outputs=structured_outputs,
+            use_json_mode=use_json_mode,
             markdown=True,
             debug_mode=debug or self.config.debug,
             # Unified memory via LearningMachine (per-user + institutional)
@@ -634,6 +664,32 @@ class AgentHarness:
         )
         # Per-run tool step tracking for progress events and duration metrics.
         self._tool_step_state: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def _close_storage_resource(storage: Any) -> None:
+        if storage is None:
+            return
+
+        session_factory = getattr(storage, "Session", None)
+        remover = getattr(session_factory, "remove", None)
+        if callable(remover):
+            try:
+                remover()
+            except Exception:
+                logger.debug("Failed to remove scoped storage sessions", exc_info=True)
+
+        closer = getattr(storage, "close", None)
+        if callable(closer):
+            try:
+                closer()
+            except Exception:
+                logger.debug("Failed to close storage backend", exc_info=True)
+
+    @staticmethod
+    def _finalize_resources(storage: Any, sandbox_dir: str | None) -> None:
+        AgentHarness._close_storage_resource(storage)
+        if sandbox_dir:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
 
     def _resolve_sandbox_dir(
         self,
@@ -3405,6 +3461,30 @@ class AgentHarness:
         finally:
             self._cleanup_sandbox_dir()
         return summary
+
+    def close(self) -> None:
+        """Release owned resources held by this harness."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._finalizer.alive:
+            self._finalizer()
+
+    async def aclose(self) -> None:
+        """Async-compatible close alias."""
+        self.close()
+
+    def __enter__(self) -> AgentHarness:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    async def __aenter__(self) -> AgentHarness:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
 
     async def _generate_session_summary(self) -> str | None:
         """Generate a short summary of the current session via a cheap LLM call."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -393,6 +393,69 @@ async def test_agent_harness_session_sandbox_end_to_end(tmp_path):
     assert not sandbox_dir.exists()
 
 
+def test_agent_harness_close_closes_owned_storage_once(tmp_path):
+    from agnoclaw.agent import AgentHarness
+    from agnoclaw.config import HarnessConfig
+
+    storage = MagicMock()
+    storage.Session.remove = MagicMock()
+    storage.close = MagicMock()
+
+    with patch("agnoclaw.agent.Agent", return_value=MagicMock()):
+        with patch("agnoclaw.agent._make_db", return_value=storage):
+            harness = AgentHarness(
+                workspace_dir=tmp_path,
+                config=HarnessConfig(),
+            )
+
+    harness.close()
+    harness.close()
+
+    storage.Session.remove.assert_called_once_with()
+    storage.close.assert_called_once_with()
+
+
+def test_agent_harness_close_does_not_close_injected_storage(tmp_path):
+    from agnoclaw.agent import AgentHarness
+    from agnoclaw.config import HarnessConfig
+
+    storage = MagicMock()
+    storage.Session.remove = MagicMock()
+    storage.close = MagicMock()
+
+    with patch("agnoclaw.agent.Agent", return_value=MagicMock()):
+        harness = AgentHarness(
+            workspace_dir=tmp_path,
+            config=HarnessConfig(),
+            db=storage,
+        )
+
+    harness.close()
+
+    storage.Session.remove.assert_not_called()
+    storage.close.assert_not_called()
+
+
+def test_agent_harness_context_manager_closes_owned_storage(tmp_path):
+    from agnoclaw.agent import AgentHarness
+    from agnoclaw.config import HarnessConfig
+
+    storage = MagicMock()
+    storage.Session.remove = MagicMock()
+    storage.close = MagicMock()
+
+    with patch("agnoclaw.agent.Agent", return_value=MagicMock()):
+        with patch("agnoclaw.agent._make_db", return_value=storage):
+            with AgentHarness(
+                workspace_dir=tmp_path,
+                config=HarnessConfig(),
+            ) as harness:
+                assert harness is not None
+
+    storage.Session.remove.assert_called_once_with()
+    storage.close.assert_called_once_with()
+
+
 def test_agent_harness_passes_backend_to_default_tools(tmp_path):
     from agnoclaw.agent import AgentHarness
     from agnoclaw.config import HarnessConfig
@@ -411,6 +474,44 @@ def test_agent_harness_passes_backend_to_default_tools(tmp_path):
     assert mock_tools.call_args[1]["backend"] is backend
 
 
+def test_agent_harness_forwards_structured_output_options(tmp_path):
+    from agnoclaw.agent import AgentHarness
+    from agnoclaw.config import HarnessConfig
+
+    captured_kwargs = {}
+
+    def _agent_ctor(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        mock_agent = MagicMock()
+        mock_agent.system_message = kwargs.get("system_message")
+        mock_agent.session_id = kwargs.get("session_id")
+        return mock_agent
+
+    with patch("agnoclaw.agent.Agent", side_effect=_agent_ctor):
+        with patch("agnoclaw.agent._make_db", return_value=MagicMock()):
+            AgentHarness(
+                workspace_dir=tmp_path,
+                config=HarnessConfig(),
+                output_schema={"type": "object"},
+                parser_model="anthropic:claude-haiku-4-5",
+                parser_model_prompt="parse this",
+                output_model="anthropic:claude-haiku-4-5",
+                output_model_prompt="rewrite this",
+                parse_response=False,
+                structured_outputs=True,
+                use_json_mode=True,
+            )
+
+    assert captured_kwargs["output_schema"] == {"type": "object"}
+    assert captured_kwargs["parser_model"] == "anthropic:claude-haiku-4-5"
+    assert captured_kwargs["parser_model_prompt"] == "parse this"
+    assert captured_kwargs["output_model"] == "anthropic:claude-haiku-4-5"
+    assert captured_kwargs["output_model_prompt"] == "rewrite this"
+    assert captured_kwargs["parse_response"] is False
+    assert captured_kwargs["structured_outputs"] is True
+    assert captured_kwargs["use_json_mode"] is True
+
+
 def test_runtime_backend_requires_command_and_workspace_together():
     with pytest.raises(ValueError, match="both command_executor and workspace_adapter"):
         RuntimeBackend(command_executor=object())
@@ -422,6 +523,18 @@ def test_agent_harness_instructions_param():
     import inspect
     sig = inspect.signature(AgentHarness.__init__)
     assert "instructions" in sig.parameters
+
+
+def test_agent_harness_accepts_structured_output_params():
+    """AgentHarness should expose Agno structured-output constructor options."""
+    from agnoclaw.agent import AgentHarness
+    import inspect
+
+    sig = inspect.signature(AgentHarness.__init__)
+    assert "output_schema" in sig.parameters
+    assert "parser_model" in sig.parameters
+    assert "parse_response" in sig.parameters
+    assert "output_model" in sig.parameters
 
 
 def test_agent_harness_legacy_model_id_param():

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "agnoclaw"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },


### PR DESCRIPTION
## Summary
- add deterministic AgentHarness shutdown for owned SQLite-backed storage and context-manager support
- forward Agno structured-output constructor options through the harness
- add regression coverage for lifecycle cleanup and structured-output passthrough
- bump package version to 0.7.4

## Testing
- uv run --extra dev pytest tests/test_agent.py tests/test_agent_coverage.py -q

## Notes
- full pytest still depends on optional Ollama/live-model setup for the existing integration tests