### PR TITLE
fix: upgrade Agno to resolve Claude structured output warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     # Core framework
-    "agno>=2.5.0",
+    "agno>=2.6.4",
     # Config
     # tomli not needed — Python 3.13+ has tomllib in stdlib
     "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.7.4"
+version = "0.7.5"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -88,4 +88,4 @@ __all__ = [
     "Workspace",
 ]
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -537,6 +537,23 @@ def test_agent_harness_accepts_structured_output_params():
     assert "output_model" in sig.parameters
 
 
+def test_agno_claude_sonnet_4_6_supports_structured_outputs():
+    from pydantic import BaseModel
+    from agno.models.anthropic import Claude
+    from unittest.mock import patch
+    import agno.models.anthropic.claude as claude_module
+
+    class DummySchema(BaseModel):
+        value: int
+
+    model = Claude(id="claude-sonnet-4-6")
+    assert getattr(model, "supports_native_structured_outputs", False) is True
+
+    with patch.object(claude_module, "log_warning") as mock_warning:
+        assert model._using_structured_outputs(response_format=DummySchema, tools=None) is True
+        mock_warning.assert_not_called()
+
+
 def test_agent_harness_legacy_model_id_param():
     """AgentHarness should still accept legacy model_id param."""
     from agnoclaw.agent import AgentHarness

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agno"
-version = "2.5.3"
+version = "2.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -25,9 +25,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/f5/9a3974f40c99ed86fd379a9e386d05e1eca9280d816396a2fa5ef86cf203/agno-2.5.3.tar.gz", hash = "sha256:790a4332b9b94feda911f979fab533ac579d5dbe87fc45b6ce4337a0d3c6cd0a", size = 1668587, upload-time = "2026-02-19T21:00:27.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/6b/f8ffb628ca219c0bd791c6eb10c1d4f312a06c761b67f1640d44cca1767c/agno-2.6.4.tar.gz", hash = "sha256:9ee7d5517e1c26760c5e489735fb547e2088248a9aec291e3c82bf2bbaef1482", size = 1989196, upload-time = "2026-04-28T13:04:27.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/3d/2e1d33a5eca9755eca4ed326ab8c83bdc97dde648b42747967546913ac3c/agno-2.5.3-py3-none-any.whl", hash = "sha256:fece1aa685e29f50d596c104ae11876b6940cbc802f47b364f67d339ddd18341", size = 2003661, upload-time = "2026-02-19T21:00:24.615Z" },
+    { url = "https://files.pythonhosted.org/packages/42/11/961ebe193afd7ae95985fd5ddb7c7b3d407998a4826b3a91dba6ef0c7231/agno-2.6.4-py3-none-any.whl", hash = "sha256:a28b8a3dfdbcdabefbc5f345e0068c3a1d7556aa2d0019caaa30160e73ff1cb9", size = 2361858, upload-time = "2026-04-28T13:04:25.24Z" },
 ]
 
 [[package]]
@@ -113,7 +113,7 @@ tui = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agno", specifier = ">=2.5.0" },
+    { name = "agno", specifier = ">=2.6.4" },
     { name = "agnoclaw", extras = ["tui"], marker = "extra == 'full'" },
     { name = "anthropic", specifier = ">=0.83.0" },
     { name = "anthropic", marker = "extra == 'all-models'", specifier = ">=0.40.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "agnoclaw"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },


### PR DESCRIPTION
## Summary
- upgrade Agno to the current stable release so Claude Sonnet 4.6 is recognized as supporting structured outputs
- lock the repo to `agno>=2.6.4` and refresh `uv.lock`
- add a regression test covering the `claude-sonnet-4-6` structured-output capability path

Fixes #45.

## Root cause
The repo was effectively resolving `agno 2.5.3`, where Agno's Claude capability table still treated `claude-sonnet-4-6` as lacking native structured outputs. In `agno 2.6.4`, that capability is reported correctly and the false warning path is avoided.

## Testing
- `uv run --extra dev pytest tests/test_agent.py tests/test_agent_coverage.py -q`
- `uv run --extra dev pytest -q -k 'not ollama and not live_agent and not session_persistence'`
