### PR TITLE
ci: auto-tag on version bump merged to main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,37 @@
+name: Auto-tag on version bump
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create tag if pyproject version is new
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from pyproject.toml
+        id: ver
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag if missing
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed $TAG — publish.yml will take it from here."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-tag.yml` that reads `pyproject.toml` on every push to `main` and creates `v<version>` if the tag is missing.
- The existing `publish.yml` already fires on `v*` tags, so this closes the loop: bump version → merge → tag → PyPI.
- Motivated by 0.7.4 silently never reaching PyPI because no one ran `git tag v0.7.4 && git push --tags` after #44.

## Test plan
- [ ] Merge this PR — workflow runs but `v0.7.5` is being backfilled separately, so the auto-tag job will be a no-op on first run (tag already exists).
- [ ] Next version bump PR should automatically produce a tag and a PyPI release with no manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)