### PR TITLE
Per-run tool scoping + input-schema specialization for skill runs (#49)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -60,7 +60,8 @@ metadata:
 | `description` | string | `""` | Shown in skill list; used for selective injection |
 | `user-invocable` | bool | `true` | Can users activate via `/skill name`? |
 | `disable-model-invocation` | bool | `false` | Prevent model from self-activating |
-| `allowed-tools` | string or list | `[]` | Comma-separated or YAML list of allowed tool names |
+| `allowed-tools` | string or list | `[]` | Comma-separated or YAML list of allowed tool names. When set, a run with this skill sees **only** these tools (restored after the run). See [Per-run tool scoping](#per-run-tool-scoping). |
+| `tool-schemas` | map | `{}` | Per-tool input-schema specialization: tool name → JSON Schema. During the run, the named tool advertises this schema (restored after). See [Per-run tool scoping](#per-run-tool-scoping). |
 | `model` | string | agent default | Model override for this skill (e.g. `"claude-opus-4-6"`) |
 | `context` | string | `null` | Set to `"fork"` to run as isolated subagent (parsed, not yet enforced) |
 | `argument-hint` | string | `null` | Hint shown in CLI tab completion |
@@ -109,6 +110,71 @@ install:
 | `go` | `go install <pkg>` | Go binaries |
 
 Install runs only if the package is not already importable (Python) or binary is not on PATH (brew/npm/go).
+
+---
+
+## Per-run tool scoping
+
+A skill can shape the toolset the model sees **for the duration of a single run**,
+without persisting any change to the agent. Two declarations drive this:
+
+### `allowed-tools` — restrict the visible toolset
+
+When a run is invoked with a skill that declares `allowed-tools`, the model sees
+only those tools for that run; the full toolset is restored afterward. This now
+applies to **inline** skill runs (`harness.run(msg, skill="...")`), not just
+`context: fork` skills. It also suppresses the harness's own default toolkits
+(bash/files/web/subagent), which a consumer otherwise can't strip — useful when a
+skill's entire job is to call one tool and you don't want the model wandering to
+`write_file` or `spawn_subagent`.
+
+```yaml
+allowed-tools: save_artifact
+```
+
+A tool name nested in a toolkit is surfaced on its own, so you can expose a single
+function without its siblings. An empty/absent `allowed-tools` means "no
+restriction" (consistent with the fork path).
+
+### `tool-schemas` — specialize a tool's input schema
+
+A generic "save"-style tool often exposes an untyped `content: dict`, leaving the
+model to guess field names. `tool-schemas` lets the skill advertise the exact
+typed shape for that run:
+
+```yaml
+allowed-tools: save_artifact
+tool-schemas:
+  save_artifact:
+    type: object
+    properties:
+      content:
+        type: object
+        properties:
+          company_id: { type: string }
+          new_money:  { type: number }
+          pre_money:  { type: number }
+        required: [company_id, new_money, pre_money]
+    required: [content]
+```
+
+During the run the model sees the specialized schema; the original is restored
+after. You can also pass schemas programmatically per call:
+
+```python
+harness.run(msg, skill="saver", tool_schema_overrides={"save_artifact": {...}})
+```
+
+Notes:
+
+- This shapes the model's **tool-call input**. It is distinct from `output_schema`,
+  which parses the model's **final text response**.
+- The harness still recomputes the *top-level* `required` from the tool's
+  signature and forces `additionalProperties: false` (an Agno behavior). Overrides
+  reliably control nested shapes, types, and descriptions.
+- Scoping mutates the live agent for one run, so a single harness instance should
+  not have two scoped runs in flight at once (same constraint as the per-run
+  system-prompt swap).
 
 ---
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -136,11 +136,18 @@ A tool name nested in a toolkit is surfaced on its own, so you can expose a sing
 function without its siblings. An empty/absent `allowed-tools` means "no
 restriction" (consistent with the fork path).
 
-### `tool-schemas` — specialize a tool's input schema
+**This is the common case, and it's all most skills need.** You only name the
+tool — the harness already knows that tool and the input schema it was registered
+with, and advertises that schema as-is. You do **not** restate the schema in
+`SKILL.md`.
 
-A generic "save"-style tool often exposes an untyped `content: dict`, leaving the
-model to guess field names. `tool-schemas` lets the skill advertise the exact
-typed shape for that run:
+### `tool-schemas` — specialize a tool's input schema (optional)
+
+`tool-schemas` is an escape hatch for the one case `allowed-tools` can't cover: a
+tool whose *registered* schema is too loose. A generic "save"-style tool often
+exposes an untyped `content: dict`, leaving the model to guess field names. When
+you want a tighter, typed shape **for this skill's run only** (without changing the
+tool's registration), declare it here:
 
 ```yaml
 allowed-tools: save_artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.7.5"
+version = "0.8.0"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -161,4 +161,4 @@ __all__ = [
     "trust_pack",
 ]
 
-__version__ = "0.7.5"
+__version__ = "0.8.0"

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -5033,20 +5033,18 @@ class AgentHarness:
             # Per-run tool scoping: honor the active skill's allowed_tools and any
             # tool input-schema specialization for this run only.
             #
-            # Non-streaming runs execute the whole model loop inside the awaited
-            # call below, so we apply the scope here and restore it in the outer
-            # finally. Streaming runs execute lazily as the caller drains the
-            # generator, so the scope is applied *inside* _wrapped_stream — binding
-            # its lifetime to generator execution. Applying it here for a stream
-            # would leak permanently if the caller never drains it, because an
-            # unstarted generator's finally never runs.
+            # The scope is applied where the model loop actually runs: a coroutine
+            # executes on ``await`` below (every non-streaming run, plus any
+            # stream=True call that Agno resolves to a non-iterable RunOutput), so
+            # we scope it around that await and restore in the outer finally. A
+            # true async generator runs lazily as the caller drains it, so its
+            # scope is applied *inside* _wrapped_stream — binding its lifetime to
+            # generator execution. Applying it before returning the generator would
+            # leak permanently if the caller never drains it (an unstarted
+            # generator's finally never runs).
             scope_allowed, scope_overrides = self._skill_tool_scope_args(
                 scoped_skill_obj, tool_schema_overrides
             )
-            if not stream:
-                tool_scope = self._apply_tool_scope(
-                    allowed=scope_allowed, schema_overrides=scope_overrides
-                )
 
             agno_call = self._agent.arun(
                 prompt.user_message,
@@ -5064,6 +5062,10 @@ class AgentHarness:
             if hasattr(agno_call, "__anext__") or hasattr(agno_call, "__aiter__"):
                 result = agno_call
             else:
+                # Coroutine: the whole loop runs on await — scope it here.
+                tool_scope = self._apply_tool_scope(
+                    allowed=scope_allowed, schema_overrides=scope_overrides
+                )
                 result = await agno_call
 
             if self._agent.system_message != base_prompt:

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -54,6 +54,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -492,6 +493,42 @@ class _ElevatedSessionCommandExecutor:
         if task_id in self._elevated_task_ids:
             return self._host_executor.kill(task_id=task_id, force=force)
         return self._sandbox_executor.kill(task_id=task_id, force=force)
+
+
+class _ToolScope:
+    """A reversible, per-run view over an Agno agent's toolset.
+
+    Captures the agent's original ``tools`` list and the original parameter
+    schema of any tool whose schema is overridden, so the run can:
+
+      * hide tools the active skill did not allow (``allowed_tools``), and
+      * advertise a specialized input schema for named tools,
+
+    then restore everything exactly on exit. No persisted mutation survives a
+    run: ``restore()`` is idempotent and always returns the agent to its
+    construction-time toolset.
+    """
+
+    __slots__ = ("_agent", "_original_tools", "_param_backups", "_restored")
+
+    def __init__(self, agent: Any, original_tools: Any) -> None:
+        self._agent = agent
+        self._original_tools = original_tools
+        # list of (function_object, original_parameters_dict)
+        self._param_backups: list[tuple[Any, dict[str, Any]]] = []
+        self._restored = False
+
+    def record_param_override(self, function: Any, original_parameters: dict[str, Any]) -> None:
+        self._param_backups.append((function, original_parameters))
+
+    def restore(self) -> None:
+        if self._restored:
+            return
+        self._restored = True
+        self._agent.tools = self._original_tools
+        # Restore in reverse so repeated overrides of the same object unwind cleanly.
+        for function, original_parameters in reversed(self._param_backups):
+            function.parameters = original_parameters
 
 
 class AgentHarness:
@@ -1053,6 +1090,137 @@ class AgentHarness:
                 if name:
                     names.add(str(name))
         return names
+
+    @staticmethod
+    def _single_tool_name(tool: Any) -> str | None:
+        """Return the advertised name of a standalone (non-Toolkit) tool."""
+        if isinstance(tool, Function):
+            return str(tool.name) if tool.name else None
+        name = getattr(tool, "name", None) or getattr(tool, "__name__", None)
+        return str(name) if name else None
+
+    def _resolve_function_objects(self, tools: list[Any]) -> dict[str, Any]:
+        """Map advertised tool name → the live Function object backing it.
+
+        Used by schema specialization to reach the exact object the model copies
+        from at run time, including functions nested inside a Toolkit. Plain
+        callables (not yet wrapped as a Function) have no mutable ``parameters``
+        attribute and are skipped.
+        """
+        resolved: dict[str, Any] = {}
+        for tool in tools:
+            if isinstance(tool, Toolkit):
+                for name, function in tool.functions.items():
+                    resolved.setdefault(str(name), function)
+            elif isinstance(tool, Function):
+                if tool.name:
+                    resolved.setdefault(str(tool.name), tool)
+        return resolved
+
+    def _apply_tool_scope(
+        self,
+        *,
+        allowed: list[str] | None = None,
+        schema_overrides: dict[str, dict[str, Any]] | None = None,
+    ) -> _ToolScope | None:
+        """Scope the agent's toolset for a single run, returning a restore token.
+
+        ``allowed`` restricts the tools visible to the model to exactly those
+        names (functions nested in toolkits are surfaced individually so a single
+        function can be exposed without its sibling tools). ``schema_overrides``
+        maps a tool name → a JSON Schema dict to advertise as that tool's input
+        schema for the run. Both are reverted by :meth:`_restore_tool_scope`.
+
+        Returns ``None`` when there is nothing to scope, so callers pay no cost on
+        the common (no-skill / unrestricted) path.
+
+        Caveats (shared-state, matching the harness's existing per-run
+        ``system_message`` swap):
+
+        * This mutates the live ``Agent.tools`` for the duration of one run, so a
+          single harness instance must not have two scoped runs in flight at once
+          — concurrent runs would observe each other's toolset. Restoration is
+          tied to the run's lifecycle (see :meth:`run`/:meth:`arun`).
+        * Scoping acts on ``Agent.tools``. A caller that supplies its own per-run
+          tool list (Agno's ``run_context.tools`` / a ``tools=`` run kwarg) takes
+          precedence in Agno and bypasses this filter.
+        * For ``schema_overrides``, Agno still recomputes the *top-level*
+          ``required`` from the tool's entrypoint signature and forces
+          ``additionalProperties: False`` (see ``Function.process_entrypoint``).
+          Overrides reliably control nested shapes, types, and descriptions; the
+          top-level required set follows the entrypoint.
+        """
+        allowed_present = allowed is not None
+        overrides_present = bool(schema_overrides)
+        if not allowed_present and not overrides_present:
+            return None
+
+        original_tools = self._agent.tools
+        scope = _ToolScope(self._agent, original_tools)
+
+        current: list[Any] = list(original_tools) if isinstance(original_tools, list) else []
+        if allowed_present:
+            allowed_set = {str(name) for name in (allowed or [])}
+            scoped: list[Any] = []
+            seen: set[str] = set()
+            for tool in current:
+                if isinstance(tool, Toolkit):
+                    for raw_name, function in tool.functions.items():
+                        fn_name = str(raw_name)
+                        if fn_name in allowed_set and fn_name not in seen:
+                            seen.add(fn_name)
+                            scoped.append(function)
+                else:
+                    tool_name = self._single_tool_name(tool)
+                    if tool_name is not None and tool_name in allowed_set and tool_name not in seen:
+                        seen.add(tool_name)
+                        scoped.append(tool)
+            working = scoped
+            self._agent.tools = scoped
+        else:
+            working = current
+
+        if overrides_present:
+            by_name = self._resolve_function_objects(working)
+            for override_name, schema in (schema_overrides or {}).items():
+                target_fn = by_name.get(str(override_name))
+                if target_fn is None or not hasattr(target_fn, "parameters"):
+                    continue
+                scope.record_param_override(target_fn, target_fn.parameters)
+                # Deep-copy so the advertised schema can't be mutated in place by
+                # Agno's per-run processing (which sets additionalProperties/required).
+                target_fn.parameters = copy.deepcopy(schema)
+
+        return scope
+
+    @staticmethod
+    def _restore_tool_scope(scope: _ToolScope | None) -> None:
+        """Restore a toolset previously scoped by :meth:`_apply_tool_scope`."""
+        if scope is not None:
+            scope.restore()
+
+    @staticmethod
+    def _skill_tool_scope_args(
+        skill_obj: Any,
+        tool_schema_overrides: dict[str, dict[str, Any]] | None,
+    ) -> tuple[list[str] | None, dict[str, dict[str, Any]] | None]:
+        """Resolve (allowed, schema_overrides) for the inline-skill scope.
+
+        ``allowed_tools`` from the skill restricts the toolset; explicit
+        ``tool_schema_overrides`` passed to run/arun take precedence over the
+        skill's declared ``tool_schemas``.
+        """
+        allowed: list[str] | None = None
+        skill_schemas: dict[str, dict[str, Any]] = {}
+        if skill_obj is not None:
+            meta = getattr(skill_obj, "meta", None)
+            if meta is not None:
+                if getattr(meta, "allowed_tools", None):
+                    allowed = list(meta.allowed_tools)
+                if getattr(meta, "tool_schemas", None):
+                    skill_schemas = dict(meta.tool_schemas)
+        overrides = {**skill_schemas, **(tool_schema_overrides or {})}
+        return allowed, (overrides or None)
 
     @staticmethod
     def _find_plan_signal_toolkit(tools: list[Any]) -> PlanSignalToolkit | None:
@@ -4217,6 +4385,7 @@ class AgentHarness:
         context: ExecutionContext | None = None,
         metadata: dict[str, Any] | None = None,
         output_schema: type | None = None,
+        tool_schema_overrides: dict[str, dict[str, Any]] | None = None,
         **kwargs,
     ) -> RunOutput | Iterator[RunOutputEvent]:
         """Run the agent on a message."""
@@ -4253,6 +4422,8 @@ class AgentHarness:
         )
         base_prompt = self._agent.system_message
         stream_cleanup_deferred = False
+        tool_scope: _ToolScope | None = None
+        scoped_skill_obj: Any = None
 
         self._emit_event_sync(
             event_type="run.started",
@@ -4368,6 +4539,7 @@ class AgentHarness:
                         return tool_result
 
                     self._set_system_prompt(skill_content=skill_content, session_id=effective_session)
+                    scoped_skill_obj = skill_obj
 
             prompt = PromptEnvelope(
                 system_prompt=self._agent.system_message,
@@ -4422,6 +4594,24 @@ class AgentHarness:
             if isinstance(extra_metadata, dict):
                 agent_metadata.update(extra_metadata)
 
+            # Per-run tool scoping: honor the active skill's allowed_tools and any
+            # tool input-schema specialization for this run only.
+            #
+            # Non-streaming runs execute the whole model loop synchronously inside
+            # the call below, so we apply the scope here and restore it in the
+            # outer finally. Streaming runs execute lazily as the caller drains the
+            # generator, so the scope is applied *inside* _wrapped_stream — binding
+            # its lifetime to generator execution. Applying it here for a stream
+            # would leak permanently if the caller never drains it, because an
+            # unstarted generator's finally never runs.
+            scope_allowed, scope_overrides = self._skill_tool_scope_args(
+                scoped_skill_obj, tool_schema_overrides
+            )
+            if not stream:
+                tool_scope = self._apply_tool_scope(
+                    allowed=scope_allowed, schema_overrides=scope_overrides
+                )
+
             result = self._agent.run(
                 prompt.user_message,
                 stream=stream,
@@ -4443,7 +4633,14 @@ class AgentHarness:
                     cumulative = ""
                     stream_error_signal: dict[str, Any] | None = None
                     run_failed_emitted = False
+                    stream_scope: _ToolScope | None = None
                     try:
+                        # Apply the tool scope here so its lifetime equals the
+                        # generator's. Agno resolves tools lazily during iteration,
+                        # so this is active before the first model request.
+                        stream_scope = self._apply_tool_scope(
+                            allowed=scope_allowed, schema_overrides=scope_overrides
+                        )
                         for event in result:
                             source_event = self._event_name(event) or None
                             stream_summary = self._stream_event_summary(event)
@@ -4581,6 +4778,7 @@ class AgentHarness:
                             raise harness_error from exc
                         raise
                     finally:
+                        self._restore_tool_scope(stream_scope)
                         self._cleanup_tool_step_state(run_id)
 
                 stream_cleanup_deferred = True
@@ -4654,6 +4852,7 @@ class AgentHarness:
             ) from exc
         finally:
             if not stream_cleanup_deferred:
+                self._restore_tool_scope(tool_scope)
                 self._cleanup_tool_step_state(run_id)
 
     async def arun(
@@ -4669,6 +4868,7 @@ class AgentHarness:
         context: ExecutionContext | None = None,
         metadata: dict[str, Any] | None = None,
         output_schema: type | None = None,
+        tool_schema_overrides: dict[str, dict[str, Any]] | None = None,
         **kwargs,
     ) -> RunOutput | AsyncIterator[RunOutputEvent]:
         """Async version of run()."""
@@ -4705,6 +4905,8 @@ class AgentHarness:
         )
         base_prompt = self._agent.system_message
         stream_cleanup_deferred = False
+        tool_scope: _ToolScope | None = None
+        scoped_skill_obj: Any = None
 
         await self._emit_event_async(
             event_type="run.started",
@@ -4773,6 +4975,7 @@ class AgentHarness:
                 )
                 if skill_content:
                     self._set_system_prompt(skill_content=skill_content, session_id=effective_session)
+                    scoped_skill_obj = self.skills._get_skill(run_input.skill)
 
             prompt = PromptEnvelope(
                 system_prompt=self._agent.system_message,
@@ -4827,6 +5030,24 @@ class AgentHarness:
             if isinstance(extra_metadata, dict):
                 agent_metadata.update(extra_metadata)
 
+            # Per-run tool scoping: honor the active skill's allowed_tools and any
+            # tool input-schema specialization for this run only.
+            #
+            # Non-streaming runs execute the whole model loop inside the awaited
+            # call below, so we apply the scope here and restore it in the outer
+            # finally. Streaming runs execute lazily as the caller drains the
+            # generator, so the scope is applied *inside* _wrapped_stream — binding
+            # its lifetime to generator execution. Applying it here for a stream
+            # would leak permanently if the caller never drains it, because an
+            # unstarted generator's finally never runs.
+            scope_allowed, scope_overrides = self._skill_tool_scope_args(
+                scoped_skill_obj, tool_schema_overrides
+            )
+            if not stream:
+                tool_scope = self._apply_tool_scope(
+                    allowed=scope_allowed, schema_overrides=scope_overrides
+                )
+
             agno_call = self._agent.arun(
                 prompt.user_message,
                 stream=stream,
@@ -4855,7 +5076,14 @@ class AgentHarness:
                     cumulative = ""
                     stream_error_signal: dict[str, Any] | None = None
                     run_failed_emitted = False
+                    stream_scope: _ToolScope | None = None
                     try:
+                        # Apply the tool scope here so its lifetime equals the
+                        # generator's. Agno resolves tools lazily during iteration,
+                        # so this is active before the first model request.
+                        stream_scope = self._apply_tool_scope(
+                            allowed=scope_allowed, schema_overrides=scope_overrides
+                        )
                         async for event in result:
                             source_event = self._event_name(event) or None
                             stream_summary = self._stream_event_summary(event)
@@ -4993,6 +5221,7 @@ class AgentHarness:
                             raise harness_error from exc
                         raise
                     finally:
+                        self._restore_tool_scope(stream_scope)
                         self._cleanup_tool_step_state(run_id)
 
                 stream_cleanup_deferred = True
@@ -5066,6 +5295,7 @@ class AgentHarness:
             ) from exc
         finally:
             if not stream_cleanup_deferred:
+                self._restore_tool_scope(tool_scope)
                 self._cleanup_tool_step_state(run_id)
 
     def print_response(self, message: str, *, stream: bool = True, skill: str | None = None, **kwargs) -> None:

--- a/src/agnoclaw/skills/loader.py
+++ b/src/agnoclaw/skills/loader.py
@@ -83,6 +83,11 @@ class SkillMeta:
     user_invocable: bool = True
     disable_model_invocation: bool = False
     allowed_tools: list[str] = field(default_factory=list)
+    # Per-run tool input-schema specialization: tool name → JSON Schema dict.
+    # During a run with this skill, each named tool advertises this schema as its
+    # input shape (restored afterward), so a generic "save"-style tool can expose
+    # the exact typed payload the skill expects for that turn.
+    tool_schemas: dict[str, dict] = field(default_factory=dict)
     model: Optional[str] = None
     context: Optional[str] = None       # "fork" for isolated subagent
     argument_hint: Optional[str] = None
@@ -217,6 +222,25 @@ def load_skill_from_path(skill_md_path: Path) -> Optional[Skill]:
     else:
         allowed_tools = list(allowed_tools_raw)
 
+    # Parse per-run tool input schemas (tool name → JSON Schema object).
+    tool_schemas_raw = metadata.get("tool-schemas", metadata.get("tool_schemas", {}))
+    if isinstance(tool_schemas_raw, str):
+        try:
+            import json as _json
+            tool_schemas_raw = _json.loads(tool_schemas_raw)
+        except Exception:
+            tool_schemas_raw = {}
+    tool_schemas: dict[str, dict] = {}
+    if isinstance(tool_schemas_raw, dict):
+        for tool_name, schema in tool_schemas_raw.items():
+            if isinstance(schema, dict):
+                tool_schemas[str(tool_name)] = schema
+            else:
+                logger.warning(
+                    "Skill '%s': ignoring non-object tool schema for %r",
+                    name, tool_name,
+                )
+
     # Parse OpenClaw gating metadata.
     # Accepts aliases: metadata.openclaw, metadata.clawdbot, metadata.clawdis
     raw_meta = metadata.get("metadata") or {}
@@ -270,6 +294,7 @@ def load_skill_from_path(skill_md_path: Path) -> Optional[Skill]:
             metadata.get("disable_model_invocation", False),
         ),
         allowed_tools=allowed_tools,
+        tool_schemas=tool_schemas,
         model=metadata.get("model"),
         context=metadata.get("context"),
         argument_hint=metadata.get("argument-hint", metadata.get("argument_hint")),

--- a/tests/test_tool_scoping.py
+++ b/tests/test_tool_scoping.py
@@ -407,6 +407,38 @@ async def test_arun_honors_allowed_tools_inline(harness: AgentHarness, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_arun_stream_resolving_to_coroutine_still_scopes(
+    harness: AgentHarness, monkeypatch
+) -> None:
+    """stream=True that Agno resolves to a non-iterable RunOutput must still scope.
+
+    Regression: scoping was gated on `not stream`, so a stream=True call whose
+    result wasn't async-iterable fell through to the non-stream path unscoped,
+    silently bypassing allowed_tools.
+    """
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    captured: dict = {}
+
+    async def fake_arun(*args, **kwargs):
+        # A coroutine that resolves to a plain (non-async-iterable) RunOutput.
+        captured["names"] = harness._tool_names(harness._agent.tools)
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "arun", fake_arun)
+
+    await harness.arun("acme 5 20", skill="saver", stream=True)
+
+    assert captured["names"] == {"save_artifact"}  # scoped during the await
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+
+
+@pytest.mark.asyncio
 async def test_arun_streaming_unconsumed_does_not_leak_scope(
     harness: AgentHarness, monkeypatch
 ) -> None:

--- a/tests/test_tool_scoping.py
+++ b/tests/test_tool_scoping.py
@@ -1,0 +1,580 @@
+"""
+Per-run tool scoping + input-schema specialization (issue #49).
+
+Covers:
+  * honoring ``allowed_tools`` for inline skills (filtering the visible toolset),
+  * per-run tool input-schema specialization (advertising a typed schema),
+  * restoration of both after the run — including on exceptions mid-run,
+  * no persisted mutation of ``Agent.tools`` across runs,
+  * SkillMeta parsing of ``tool-schemas`` frontmatter.
+
+These exercise the harness boundary directly; no model API is required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from agno.tools import Toolkit
+from agno.tools.function import Function
+
+from agnoclaw import AgentHarness, HarnessError
+from agnoclaw.skills.loader import Skill, SkillMeta, load_skill_from_path
+
+# ── Fixtures / helpers ────────────────────────────────────────────────────────
+
+
+class SaveKit(Toolkit):
+    """A toolkit with one wanted tool and two distractor tools."""
+
+    def __init__(self) -> None:
+        super().__init__(name="savekit")
+        self.register(self.save_artifact)
+        self.register(self.grep_files)
+        self.register(self.spawn_subagent)
+
+    def save_artifact(self, content: dict) -> str:
+        """Save an artifact."""
+        return "saved"
+
+    def grep_files(self, pattern: str) -> str:
+        """Grep files."""
+        return "grepped"
+
+    def spawn_subagent(self, task: str) -> str:
+        """Spawn a subagent."""
+        return "spawned"
+
+
+def standalone_tool(query: str) -> str:
+    """A standalone (non-toolkit) tool."""
+    return "ran"
+
+
+CONTENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "content": {
+            "type": "object",
+            "properties": {
+                "company_id": {"type": "string"},
+                "new_money": {"type": "number"},
+                "pre_money": {"type": "number"},
+            },
+            "required": ["company_id", "new_money", "pre_money"],
+        }
+    },
+    "required": ["content"],
+}
+
+
+@pytest.fixture
+def harness() -> AgentHarness:
+    """A harness with a known, network-free toolset (no default tools)."""
+    return AgentHarness(
+        include_default_tools=False,
+        tools=[SaveKit(), standalone_tool],
+    )
+
+
+def _advertised_parameters(function: Function) -> dict:
+    """Reproduce what Agno advertises to the model for a Function.
+
+    ``parse_tools`` deep-copies each Function and runs ``process_entrypoint``
+    before sending the schema to the provider, so we do the same here to verify
+    the *payload* (not just the stored attribute).
+    """
+    copied = function.model_copy(deep=True)
+    copied.process_entrypoint(strict=False)
+    return copied.parameters
+
+
+# ── _apply_tool_scope / _restore_tool_scope ──────────────────────────────────
+
+
+def test_allowed_tools_filters_toolkit_inline(harness: AgentHarness) -> None:
+    original = harness._agent.tools
+    scope = harness._apply_tool_scope(allowed=["save_artifact"])
+
+    assert harness._tool_names(harness._agent.tools) == {"save_artifact"}
+    # The single surfaced tool is the Function pulled out of the toolkit.
+    assert all(isinstance(t, Function) for t in harness._agent.tools)
+
+    scope.restore()
+    assert harness._agent.tools is original
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+
+
+def test_allowed_tools_can_surface_a_standalone_tool(harness: AgentHarness) -> None:
+    scope = harness._apply_tool_scope(allowed=["standalone_tool"])
+    assert harness._tool_names(harness._agent.tools) == {"standalone_tool"}
+    scope.restore()
+
+
+def test_allowed_tools_empty_list_hides_everything(harness: AgentHarness) -> None:
+    scope = harness._apply_tool_scope(allowed=[])
+    assert harness._agent.tools == []
+    scope.restore()
+    assert harness._tool_names(harness._agent.tools)  # back to full set
+
+
+def test_scope_noop_returns_none(harness: AgentHarness) -> None:
+    assert harness._apply_tool_scope(allowed=None, schema_overrides=None) is None
+    assert harness._apply_tool_scope() is None
+    # An empty override mapping is also a no-op.
+    assert harness._apply_tool_scope(schema_overrides={}) is None
+
+
+def test_schema_override_specializes_payload_and_restores(harness: AgentHarness) -> None:
+    save_fn = harness._agent.tools[0].functions["save_artifact"]
+    original_params = save_fn.parameters
+    # Baseline: content is an untyped dict — advertised with no nested properties.
+    baseline = _advertised_parameters(save_fn)
+    assert baseline["properties"]["content"].get("properties", {}) == {}
+
+    scope = harness._apply_tool_scope(
+        allowed=["save_artifact"],
+        schema_overrides={"save_artifact": CONTENT_SCHEMA},
+    )
+
+    scoped_fn = harness._agent.tools[0]
+    advertised = _advertised_parameters(scoped_fn)
+    assert list(advertised["properties"]["content"]["properties"]) == [
+        "company_id",
+        "new_money",
+        "pre_money",
+    ]
+    assert advertised["required"] == ["content"]
+
+    scope.restore()
+    # Original schema object restored by identity — no leaked mutation.
+    assert harness._agent.tools[0].functions["save_artifact"].parameters is original_params
+
+
+def test_schema_override_without_allowed_targets_toolkit_function(harness: AgentHarness) -> None:
+    save_fn = harness._agent.tools[0].functions["save_artifact"]
+    original_params = save_fn.parameters
+
+    scope = harness._apply_tool_scope(schema_overrides={"save_artifact": CONTENT_SCHEMA})
+    # Toolset is unchanged (no allowed filter) but the schema is specialized.
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+    assert "properties" in _advertised_parameters(save_fn)["properties"]["content"]
+
+    scope.restore()
+    assert save_fn.parameters is original_params
+
+
+def test_schema_override_for_unknown_tool_is_ignored(harness: AgentHarness) -> None:
+    scope = harness._apply_tool_scope(schema_overrides={"does_not_exist": CONTENT_SCHEMA})
+    # Nothing to override, but the call still produces a (restorable) scope.
+    assert scope is not None
+    scope.restore()
+
+
+def test_advertised_schema_is_isolated_from_override_dict(harness: AgentHarness) -> None:
+    """Agno mutates the schema in place per run; the caller's dict must not leak."""
+    overrides = {"save_artifact": CONTENT_SCHEMA}
+    scope = harness._apply_tool_scope(allowed=["save_artifact"], schema_overrides=overrides)
+    _advertised_parameters(harness._agent.tools[0])  # triggers in-place processing on the copy
+    # Our source dict is untouched (deep-copied on apply).
+    assert "additionalProperties" not in CONTENT_SCHEMA
+    scope.restore()
+
+
+def test_restore_is_idempotent(harness: AgentHarness) -> None:
+    original = harness._agent.tools
+    scope = harness._apply_tool_scope(allowed=["save_artifact"])
+    scope.restore()
+    scope.restore()  # second call is a no-op
+    assert harness._agent.tools is original
+
+
+def test_duplicate_tool_name_surfaces_once_and_override_matches() -> None:
+    """A name present in two toolkits is surfaced once, and the override hits it."""
+
+    class KitA(Toolkit):
+        def __init__(self) -> None:
+            super().__init__(name="kit_a")
+            self.register(self.save_artifact)
+
+        def save_artifact(self, content: dict) -> str:
+            """Save (A)."""
+            return "a"
+
+    class KitB(Toolkit):
+        def __init__(self) -> None:
+            super().__init__(name="kit_b")
+            self.register(self.save_artifact)
+
+        def save_artifact(self, content: dict) -> str:
+            """Save (B)."""
+            return "b"
+
+    h = AgentHarness(include_default_tools=False, tools=[KitA(), KitB()])
+    scope = h._apply_tool_scope(
+        allowed=["save_artifact"], schema_overrides={"save_artifact": CONTENT_SCHEMA}
+    )
+
+    # Exactly one tool is advertised (no double-listing under the same name)...
+    assert len(h._agent.tools) == 1
+    # ...and it is the one whose schema was specialized.
+    advertised = _advertised_parameters(h._agent.tools[0])
+    assert "properties" in advertised["properties"]["content"]
+
+    scope.restore()
+    assert len(h._agent.tools) == 2
+
+
+# ── _skill_tool_scope_args ────────────────────────────────────────────────────
+
+
+def test_scope_args_reads_skill_meta(harness: AgentHarness) -> None:
+    meta = SkillMeta(
+        name="saver",
+        allowed_tools=["save_artifact"],
+        tool_schemas={"save_artifact": CONTENT_SCHEMA},
+    )
+    skill = Skill(meta=meta, content="x", path=Path("x"))
+    allowed, overrides = harness._skill_tool_scope_args(skill, None)
+    assert allowed == ["save_artifact"]
+    assert overrides == {"save_artifact": CONTENT_SCHEMA}
+
+
+def test_scope_args_explicit_overrides_take_precedence(harness: AgentHarness) -> None:
+    meta = SkillMeta(name="saver", tool_schemas={"save_artifact": {"type": "object"}})
+    skill = Skill(meta=meta, content="x", path=Path("x"))
+    explicit = {"save_artifact": CONTENT_SCHEMA}
+    _allowed, overrides = harness._skill_tool_scope_args(skill, explicit)
+    assert overrides["save_artifact"] is CONTENT_SCHEMA
+
+
+def test_scope_args_no_skill(harness: AgentHarness) -> None:
+    allowed, overrides = harness._skill_tool_scope_args(None, None)
+    assert allowed is None
+    assert overrides is None
+    allowed, overrides = harness._skill_tool_scope_args(None, {"t": CONTENT_SCHEMA})
+    assert allowed is None
+    assert overrides == {"t": CONTENT_SCHEMA}
+
+
+# ── End-to-end run()/arun() integration ───────────────────────────────────────
+
+
+def _install_skill(harness: AgentHarness, meta: SkillMeta, monkeypatch) -> None:
+    skill = Skill(meta=meta, content="Read the numbers and save them.", path=Path("x"))
+    monkeypatch.setattr(harness.skills, "load_skill", lambda name: skill.content)
+    monkeypatch.setattr(harness.skills, "_get_skill", lambda name: skill)
+
+
+def test_run_honors_allowed_tools_inline_and_restores(harness: AgentHarness, monkeypatch) -> None:
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        captured["names"] = harness._tool_names(harness._agent.tools)
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "run", fake_run)
+
+    harness.run("acme 5 20", skill="saver")
+
+    # During the run, only the allowed tool was visible to the model.
+    assert captured["names"] == {"save_artifact"}
+    # After the run, the full toolset is restored (no persisted mutation).
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+    assert any(isinstance(t, Toolkit) for t in harness._agent.tools)
+
+
+def test_run_applies_schema_override_in_payload(harness: AgentHarness, monkeypatch) -> None:
+    _install_skill(
+        harness,
+        SkillMeta(
+            name="saver",
+            allowed_tools=["save_artifact"],
+            tool_schemas={"save_artifact": CONTENT_SCHEMA},
+        ),
+        monkeypatch,
+    )
+
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        (fn,) = harness._agent.tools
+        captured["params"] = _advertised_parameters(fn)
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "run", fake_run)
+
+    harness.run("acme 5 20", skill="saver")
+
+    assert list(captured["params"]["properties"]["content"]["properties"]) == [
+        "company_id",
+        "new_money",
+        "pre_money",
+    ]
+    # Restored to the untyped baseline after the run.
+    restored = harness._agent.tools[0].functions["save_artifact"]
+    assert _advertised_parameters(restored)["properties"]["content"].get("properties", {}) == {}
+
+
+def test_run_restores_scope_on_exception(harness: AgentHarness, monkeypatch) -> None:
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("model exploded mid-run")
+
+    monkeypatch.setattr(harness._agent, "run", boom)
+
+    with pytest.raises(HarnessError):
+        harness.run("acme 5 20", skill="saver")
+
+    # Toolset restored even though the run raised.
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+
+
+def test_run_without_skill_leaves_toolset_untouched(harness: AgentHarness, monkeypatch) -> None:
+    before = harness._agent.tools
+
+    def fake_run(*args, **kwargs):
+        assert harness._agent.tools is before  # no scoping applied
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "run", fake_run)
+    harness.run("hello")
+    assert harness._agent.tools is before
+
+
+def test_run_programmatic_override_without_skill(harness: AgentHarness, monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        fn = harness._agent.tools[0].functions["save_artifact"]
+        captured["params"] = _advertised_parameters(fn)
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "run", fake_run)
+    harness.run("hi", tool_schema_overrides={"save_artifact": CONTENT_SCHEMA})
+
+    assert "properties" in captured["params"]["properties"]["content"]
+    # Full toolset preserved (override only, no allowed filter).
+    assert any(isinstance(t, Toolkit) for t in harness._agent.tools)
+
+
+@pytest.mark.asyncio
+async def test_arun_honors_allowed_tools_inline(harness: AgentHarness, monkeypatch) -> None:
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    captured: dict = {}
+
+    async def fake_arun(*args, **kwargs):
+        captured["names"] = harness._tool_names(harness._agent.tools)
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "arun", fake_arun)
+
+    await harness.arun("acme 5 20", skill="saver")
+
+    assert captured["names"] == {"save_artifact"}
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+
+
+@pytest.mark.asyncio
+async def test_arun_streaming_unconsumed_does_not_leak_scope(
+    harness: AgentHarness, monkeypatch
+) -> None:
+    """Async counterpart: an abandoned async stream must not leak the scope."""
+    import gc
+
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    async def empty_stream(*args, **kwargs):
+        return
+        yield  # async generator that yields nothing
+
+    monkeypatch.setattr(harness._agent, "arun", lambda *a, **k: empty_stream())
+
+    full = {"save_artifact", "grep_files", "spawn_subagent", "standalone_tool"}
+    stream = await harness.arun("acme 5 20", skill="saver", stream=True)
+    assert harness._tool_names(harness._agent.tools) == full  # not yet applied
+    await stream.aclose()
+    assert harness._tool_names(harness._agent.tools) == full
+    del stream
+    gc.collect()
+    assert harness._tool_names(harness._agent.tools) == full
+
+
+@pytest.mark.asyncio
+async def test_arun_restores_scope_on_exception(harness: AgentHarness, monkeypatch) -> None:
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("async model exploded")
+
+    monkeypatch.setattr(harness._agent, "arun", boom)
+
+    with pytest.raises(HarnessError):
+        await harness.arun("acme 5 20", skill="saver")
+
+    assert any(isinstance(t, Toolkit) for t in harness._agent.tools)
+
+
+def test_run_streaming_scopes_during_iteration_and_restores(
+    harness: AgentHarness, monkeypatch
+) -> None:
+    """A streamed run scopes the toolset *while the generator runs*, then restores.
+
+    Agno resolves tools lazily during iteration, so the scope is applied inside the
+    stream wrapper (not at call time) and torn down in its finally.
+    """
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        def events():
+            captured["during"] = harness._tool_names(harness._agent.tools)
+            return
+            yield  # make this a generator
+
+        return events()
+
+    monkeypatch.setattr(harness._agent, "run", fake_run)
+
+    stream = harness.run("acme 5 20", skill="saver", stream=True)
+    list(stream)  # drain the wrapped stream → applies scope, then restores it
+
+    assert captured["during"] == {"save_artifact"}
+    assert harness._tool_names(harness._agent.tools) == {
+        "save_artifact",
+        "grep_files",
+        "spawn_subagent",
+        "standalone_tool",
+    }
+
+
+def test_run_streaming_unconsumed_does_not_leak_scope(
+    harness: AgentHarness, monkeypatch
+) -> None:
+    """An abandoned stream must not permanently corrupt the harness toolset.
+
+    Regression for the leak where the scope was applied before the generator was
+    returned: an unstarted generator's finally never runs, so close()/GC could not
+    restore. Binding the scope to generator execution fixes it.
+    """
+    import gc
+
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+    monkeypatch.setattr(harness._agent, "run", lambda *a, **k: iter(()))
+
+    full = {"save_artifact", "grep_files", "spawn_subagent", "standalone_tool"}
+
+    stream = harness.run("acme 5 20", skill="saver", stream=True)
+    assert harness._tool_names(harness._agent.tools) == full  # not yet applied
+    stream.close()
+    assert harness._tool_names(harness._agent.tools) == full
+    del stream
+    gc.collect()
+    assert harness._tool_names(harness._agent.tools) == full
+
+
+def test_sequential_runs_dont_leak_scope(harness: AgentHarness, monkeypatch) -> None:
+    """A scoped run must not affect a later run with a different (or no) skill."""
+    seen: list = []
+
+    def fake_run(*args, **kwargs):
+        seen.append(harness._tool_names(harness._agent.tools))
+        return SimpleNamespace(content="ok")
+
+    monkeypatch.setattr(harness._agent, "run", fake_run)
+
+    _install_skill(harness, SkillMeta(name="saver", allowed_tools=["save_artifact"]), monkeypatch)
+    harness.run("first", skill="saver")
+
+    # Second run: no skill → full toolset, proving the first run's scope was released.
+    monkeypatch.setattr(harness.skills, "load_skill", lambda name: None)
+    harness.run("second")
+
+    assert seen[0] == {"save_artifact"}
+    assert seen[1] == {"save_artifact", "grep_files", "spawn_subagent", "standalone_tool"}
+
+
+# ── Loader parsing ────────────────────────────────────────────────────────────
+
+
+def test_loader_parses_tool_schemas(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "saver"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: saver\n"
+        "description: Save a dilution seed\n"
+        "allowed-tools: save_artifact\n"
+        "tool-schemas:\n"
+        "  save_artifact:\n"
+        "    type: object\n"
+        "    properties:\n"
+        "      content:\n"
+        "        type: object\n"
+        "        properties:\n"
+        "          company_id:\n"
+        "            type: string\n"
+        "    required:\n"
+        "      - content\n"
+        "---\n\n"
+        "# Saver\n",
+        encoding="utf-8",
+    )
+
+    skill = load_skill_from_path(skill_dir / "SKILL.md")
+    assert skill is not None
+    assert skill.meta.allowed_tools == ["save_artifact"]
+    assert skill.meta.tool_schemas["save_artifact"]["properties"]["content"]["type"] == "object"
+    assert skill.meta.tool_schemas["save_artifact"]["required"] == ["content"]
+
+
+def test_loader_ignores_non_object_tool_schema(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "bad"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: bad\n"
+        "tool-schemas:\n"
+        "  save_artifact: not-a-schema\n"
+        "---\n\n# Bad\n",
+        encoding="utf-8",
+    )
+    skill = load_skill_from_path(skill_dir / "SKILL.md")
+    assert skill is not None
+    assert skill.meta.tool_schemas == {}
+
+
+def test_skillmeta_tool_schemas_defaults_empty() -> None:
+    assert SkillMeta(name="x").tool_schemas == {}


### PR DESCRIPTION
Closes #49.

## Problem

A skill run only swapped the **system prompt** — the toolset was frozen at `Agent(...)` construction and identical for every message. Two consequences, both at the harness boundary:

1. `allowed_tools` was a no-op for **inline** skills (only the `context: fork` path honored it), so the model saw the full toolset and wandered to tools the skill never intended — including the harness's *own* default Bash/Files/Web/Subagent toolkits a consumer can't strip.
2. A generic "save"-style tool could only expose an untyped `content: dict`, so the model guessed field names even when it called the right tool.

The issue includes a 6-model evidence table showing toolset breadth (not model capability) is what flips success→failure.

## What this does

A reversible, per-run view over the Agno agent's toolset (`_ToolScope` + `_apply_tool_scope`/`_restore_tool_scope`):

- **Honor `allowed_tools` inline.** A run with a skill that declares `allowed-tools` sees only those tools, restored after. Functions nested in a toolkit are surfaced individually, so a single tool can be exposed without its siblings. The harness's default toolkits are suppressed too.
- **Per-run input-schema specialization.** New `tool-schemas` skill frontmatter field (or a `tool_schema_overrides=` kwarg on `run`/`arun`) makes a named tool advertise a typed JSON schema for that run, restored afterward. Distinct from the existing `output_schema` path, which parses the model's final *text* response — this shapes the model's *tool-call input*.

## Correctness

- No persisted mutation of `Agent.tools`; restoration is idempotent and fires on the non-stream path, the streaming wrapper, and on exceptions mid-run.
- **Streaming leak fixed:** the scope is applied *inside* the stream wrapper so its lifetime equals the generator's. Applying it before returning the generator leaked permanently when a caller never drained the stream (an unstarted generator's `finally` never runs). Found via an adversarial review pass; regression-tested.
- Duplicate tool names across toolkits are surfaced once, and the override binds to the surfaced object.

## Tests

27 new unit tests in `tests/test_tool_scoping.py` — inline `allowed_tools` filtering, schema override applied + restored (verified via the advertised provider payload), restoration on exception, no cross-run leakage, sync + async streaming leak regressions, and loader parsing of `tool-schemas`. Full suite: 762 passed.

Acceptance criteria from #49:
- [x] A run with a skill whose `allowed_tools` is set sees only those tools; other runs unaffected.
- [x] A skill can declare a per-tool input schema; during the run the model sees the specialized schema, restored after.
- [x] No persisted mutation of `Agent.tools` across runs.
- [x] Works on the inline path (no `context: fork`).
- [x] Unit tests: allowed_tools inline; schema override applied + restored; restoration on exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)