### PR TITLE
Per-run dependencies/session_state + active RunContext for custom dispatch (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,45 @@ run = await harness.session(session_id="s1").send("Hello")
 async for event in run.events(): print(event)
 ```
 
+### v0.9 features (per-run dependencies + active RunContext for custom dispatch)
+
+Set caller scope once per run as `dependencies`; every tool and every custom
+dispatch adapter reads it from one agno-native contract (the run's `RunContext`),
+and the values never reach the model (unless you opt in with
+`add_dependencies_to_context=True`). Per-run values merge over the
+construction-time defaults and are scoped to that run only — leak-free across
+concurrent and sequential runs on one harness.
+
+```python
+from agno.run.base import RunContext
+from agno.tools import tool
+from agnoclaw import AgentHarness, get_current_dependencies
+
+@tool
+def whoami(run_context: RunContext) -> str:           # Agno injects run_context
+    return str((run_context.dependencies or {}).get("tenant_id"))
+
+harness = AgentHarness(tools=[whoami], dependencies={"env": "prod"})
+
+# Per-run scope — merged over construction defaults, restored after the run.
+harness.run(
+    "Who am I?",
+    dependencies={"tenant_id": "acme", "user_id": "u-123"},
+    session_state={"cart": []},          # also per-run, merged + scoped
+)
+
+# A custom dispatch adapter (no run_context parameter) reads the SAME scope:
+def my_adapter():
+    deps = get_current_dependencies()    # active during a tool dispatch
+    return deps["tenant_id"]
+
+# Harness-level session-state read/update (proxies Agno):
+harness.update_session_state({"seen": True}, session_id="s1")
+state = harness.get_session_state(session_id="s1")
+```
+
+See `examples/per_run_dependencies.py` for a runnable end-to-end demo.
+
 See [`cookbook/`](cookbook/) for complete runnable examples of each feature.
 
 ---

--- a/examples/per_run_dependencies.py
+++ b/examples/per_run_dependencies.py
@@ -1,0 +1,56 @@
+"""
+Per-run dependencies — one scope contract for caller context (issue #52).
+
+Set caller scope once per run as ``dependencies``; every tool and every custom
+dispatch adapter reads it from one agno-native contract (the run's RunContext),
+and the values never reach the model.
+
+Two readers of the same per-run scope:
+  1. A plain ``@tool`` function — Agno injects ``run_context: RunContext`` and
+     strips it from the model-facing schema.
+  2. A custom dispatch adapter — reads the active context via
+     ``get_current_dependencies()`` (no run_context parameter needed).
+
+Run: uv run python examples/per_run_dependencies.py
+"""
+
+from _utils import detect_model
+from agno.run.base import RunContext
+from agno.tools import tool
+
+from agnoclaw import AgentHarness, get_current_dependencies
+
+
+@tool
+def whoami(run_context: RunContext) -> str:
+    """Return the tenant the current request is scoped to."""
+    deps = run_context.dependencies or {}
+    # A custom dispatch adapter (no run_context param) reads the SAME scope:
+    adapter_view = get_current_dependencies() or {}
+    assert adapter_view.get("tenant_id") == deps.get("tenant_id")
+    return f"tenant={deps.get('tenant_id')} user={deps.get('user_id')}"
+
+
+agent = AgentHarness(
+    name="scoped-agent",
+    model=detect_model(),
+    tools=[whoami],
+    # Construction-time default; per-run dependencies merge over this.
+    dependencies={"env": "prod"},
+    # Keep caller scope out of the model context (the default).
+    add_dependencies_to_context=False,
+)
+
+# Set scope once for this single run — restored automatically afterwards.
+agent.print_response(
+    "Call whoami and report exactly what it returns.",
+    dependencies={"tenant_id": "acme", "user_id": "u-123"},
+    stream=True,
+)
+
+# A second run with different scope never leaks the first run's dependencies.
+agent.print_response(
+    "Call whoami again and report exactly what it returns.",
+    dependencies={"tenant_id": "globex", "user_id": "u-456"},
+    stream=True,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.8.0"
+version = "0.9.0"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -23,7 +23,13 @@ With skills:
     agent.print_response("Research quantum computing", skill="deep-research")
 """
 
-from .agent import AgentHarness, HarnessAgent  # HarnessAgent = backward compat alias
+from .agent import (  # HarnessAgent = backward compat alias
+    AgentHarness,
+    HarnessAgent,
+    get_current_dependencies,
+    get_current_run_context,
+    get_current_tool_runtime,
+)
 from .backends import RuntimeBackend, SandboxMode, normalize_sandbox_mode
 from .config import HarnessConfig, get_config
 from .packs import (
@@ -147,6 +153,9 @@ __all__ = [
     "as_agentos_agent",
     "create_agentos_app",
     "get_config",
+    "get_current_dependencies",
+    "get_current_run_context",
+    "get_current_tool_runtime",
     "normalize_sandbox_mode",
     "SubagentDefinition",
     "WorkspaceAdapter",
@@ -161,4 +170,4 @@ __all__ = [
     "trust_pack",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -144,6 +144,14 @@ _CURRENT_TOOL_RUNTIME: ContextVar[dict[str, Any] | None] = ContextVar(
     "agnoclaw_current_tool_runtime",
     default=None,
 )
+# Holds the active Agno ``RunContext`` for the duration of a tool dispatch, so a
+# custom dispatch adapter (one that does not take a ``run_context: RunContext``
+# parameter) can read caller scope — ``run_context.dependencies`` (tenant, user,
+# request-scoped ids, per-message selections) — from one agno-native contract.
+_CURRENT_RUN_CONTEXT: ContextVar[Any | None] = ContextVar(
+    "agnoclaw_current_run_context",
+    default=None,
+)
 
 # Provider name aliases → Agno's canonical provider names
 _PROVIDER_ALIASES: dict[str, str] = {
@@ -204,6 +212,36 @@ def get_current_tool_runtime() -> dict[str, Any] | None:
     if runtime is None:
         return None
     return dict(runtime)
+
+
+def get_current_run_context() -> Any | None:
+    """Return the active Agno ``RunContext`` for the current tool dispatch.
+
+    This is the documented, stable way to read caller-supplied, LLM-hidden scope
+    from inside a *custom* tool-dispatch path — an adapter that dispatches tools
+    itself instead of declaring a plain ``@tool`` function with a
+    ``run_context: RunContext`` parameter (which Agno injects for you).
+
+    The harness sets this contextvar for the duration of each tool call, so the
+    value is only populated while a tool is executing. It returns ``None`` outside
+    a tool dispatch. Read per-run scope from ``run_context.dependencies`` — the
+    same mapping ``run``/``arun`` accept as a per-run ``dependencies`` kwarg.
+    """
+    return _CURRENT_RUN_CONTEXT.get()
+
+
+def get_current_dependencies() -> dict[str, Any] | None:
+    """Return ``dependencies`` from the active run context, if any.
+
+    Convenience over :func:`get_current_run_context`; returns the active run's
+    ``dependencies`` mapping (a copy) or ``None`` when no run context is active or
+    no dependencies were set for the run.
+    """
+    run_context = _CURRENT_RUN_CONTEXT.get()
+    dependencies = getattr(run_context, "dependencies", None)
+    if isinstance(dependencies, dict):
+        return dict(dependencies)
+    return None
 
 
 def _run_output_status_value(value: Any) -> str | None:
@@ -587,7 +625,13 @@ class AgentHarness:
         skill_install_approver: Optional approval backend for skill dependency installs.
         context_providers: Optional Agno context providers to expose through the harness.
         dependencies: Optional dependency mapping propagated into Agno run context.
+                      Serves as the construction-time default that per-run
+                      ``dependencies`` (on ``run``/``arun``) are merged over.
         add_dependencies_to_context: Whether Agno should add dependencies to model context.
+                                     Leave False to keep caller scope LLM-hidden.
+        session_state: Optional session-state mapping seeded into Agno's run context.
+                       Construction-time default that per-run ``session_state`` merges over.
+        add_session_state_to_context: Whether Agno should add session_state to model context.
         packs: Optional agnoclaw pack directories or manifest paths to load.
         trusted_packs: Whether code-executing pack registrations may run.
     """
@@ -656,6 +700,8 @@ class AgentHarness:
         context_providers: list[ContextProvider] | tuple[ContextProvider, ...] | None = None,
         dependencies: dict[str, Any] | None = None,
         add_dependencies_to_context: bool = False,
+        session_state: dict[str, Any] | None = None,
+        add_session_state_to_context: bool = False,
         packs: list[str | Path] | tuple[str | Path, ...] | None = None,
         trusted_packs: bool = False,
         pre_run_hooks: list[PreRunHook] | None = None,
@@ -701,6 +747,8 @@ class AgentHarness:
         self._context_providers_setup = False
         self._dependencies = dict(dependencies or {})
         self._add_dependencies_to_context = add_dependencies_to_context
+        self._session_state = dict(session_state or {})
+        self._add_session_state_to_context = add_session_state_to_context
         self._loaded_packs: list[Any] = []
 
         # Runtime extension contracts
@@ -1007,6 +1055,8 @@ class AgentHarness:
             user_id=user_id,
             dependencies=self._dependencies or None,
             add_dependencies_to_context=self._add_dependencies_to_context,
+            session_state=self._session_state or None,
+            add_session_state_to_context=self._add_session_state_to_context,
             add_history_to_context=True,
             num_history_runs=num_history_runs or self.config.session_history_runs,
             num_history_messages=num_history_messages,
@@ -1221,6 +1271,61 @@ class AgentHarness:
                     skill_schemas = dict(meta.tool_schemas)
         overrides = {**skill_schemas, **(tool_schema_overrides or {})}
         return allowed, (overrides or None)
+
+    @staticmethod
+    def _merge_run_mapping(
+        base: dict[str, Any] | None,
+        override: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Merge a per-run mapping over a construction-time default.
+
+        Returns a fresh dict with ``override`` keys winning over ``base`` keys, or
+        ``None`` when both are empty. ``base`` is never mutated, so concurrent and
+        sequential runs on one harness never leak each other's per-run values —
+        each run builds its own merged copy that Agno resolves into its own
+        ``RunContext`` (the agent's construction-time mapping is read, not
+        rewritten).
+        """
+        if not base and not override:
+            return None
+        merged = dict(base or {})
+        if override:
+            merged.update(override)
+        return merged or None
+
+    def _resolve_run_context_kwargs(
+        self,
+        *,
+        dependencies: dict[str, Any] | None,
+        session_state: dict[str, Any] | None,
+        add_dependencies_to_context: bool | None,
+        add_session_state_to_context: bool | None,
+        knowledge_filters: dict[str, Any] | list[Any] | None,
+    ) -> dict[str, Any]:
+        """Build the per-run context/state kwargs forwarded to Agno's run/arun.
+
+        Per-run ``dependencies`` / ``session_state`` are merged over the
+        harness's construction-time defaults; the merged value is only forwarded
+        when the caller supplied a per-run value, so the default (no-kwarg) path
+        leaves Agno to use the agent-level defaults untouched. The remaining flags
+        pass straight through when provided.
+        """
+        resolved: dict[str, Any] = {}
+        if dependencies is not None:
+            resolved["dependencies"] = self._merge_run_mapping(
+                self._dependencies, dependencies
+            )
+        if session_state is not None:
+            resolved["session_state"] = self._merge_run_mapping(
+                self._session_state, session_state
+            )
+        if add_dependencies_to_context is not None:
+            resolved["add_dependencies_to_context"] = add_dependencies_to_context
+        if add_session_state_to_context is not None:
+            resolved["add_session_state_to_context"] = add_session_state_to_context
+        if knowledge_filters is not None:
+            resolved["knowledge_filters"] = knowledge_filters
+        return resolved
 
     @staticmethod
     def _find_plan_signal_toolkit(tools: list[Any]) -> PlanSignalToolkit | None:
@@ -2391,6 +2496,9 @@ class AgentHarness:
                 except HarnessError as exc:
                     self._raise_agent_run_exception(exc)
             self._handle_tool_pre_hook(fc=fc, run_context=run_context)
+            # Expose the active RunContext to custom dispatch adapters for the
+            # duration of this tool call (read via get_current_run_context()).
+            self._set_active_run_context(fc, run_context)
             runtime = getattr(fc, "_agnoclaw_tool_runtime", None)
             if isinstance(runtime, dict):
                 self._set_active_tool_runtime(fc, runtime)
@@ -2411,6 +2519,7 @@ class AgentHarness:
                 self._handle_tool_post_hook(fc=fc, run_context=run_context)
             finally:
                 self._clear_active_tool_runtime(fc)
+                self._clear_active_run_context(fc)
 
         runtime_pre_hook._agnoclaw_runtime_pre = True  # type: ignore[attr-defined]
         runtime_post_hook._agnoclaw_runtime_post = True  # type: ignore[attr-defined]
@@ -2474,6 +2583,22 @@ class AgentHarness:
             return
         _CURRENT_TOOL_RUNTIME.reset(token)
         delattr(fc, "_agnoclaw_tool_runtime_token")
+
+    @staticmethod
+    def _set_active_run_context(fc, run_context: Any) -> None:
+        token = _CURRENT_RUN_CONTEXT.set(run_context)
+        if fc is not None:
+            fc._agnoclaw_run_context_token = token
+
+    @staticmethod
+    def _clear_active_run_context(fc) -> None:
+        if fc is None:
+            return
+        token = getattr(fc, "_agnoclaw_run_context_token", None)
+        if token is None:
+            return
+        _CURRENT_RUN_CONTEXT.reset(token)
+        delattr(fc, "_agnoclaw_run_context_token")
 
     @staticmethod
     def _context_to_metadata(context: ExecutionContext) -> dict[str, Any]:
@@ -3045,6 +3170,7 @@ class AgentHarness:
 
             fc._agnoclaw_tool_runtime = {
                 "context": context,
+                "run_context": run_context,
                 "event_sink": self._event_sink,
                 "event_sink_mode": self._event_sink_mode.value,
                 "session_metadata": dict(self._session_metadata),
@@ -4386,9 +4512,33 @@ class AgentHarness:
         metadata: dict[str, Any] | None = None,
         output_schema: type | None = None,
         tool_schema_overrides: dict[str, dict[str, Any]] | None = None,
+        dependencies: dict[str, Any] | None = None,
+        session_state: dict[str, Any] | None = None,
+        add_dependencies_to_context: bool | None = None,
+        add_session_state_to_context: bool | None = None,
+        knowledge_filters: dict[str, Any] | list[Any] | None = None,
         **kwargs,
     ) -> RunOutput | Iterator[RunOutputEvent]:
-        """Run the agent on a message."""
+        """Run the agent on a message.
+
+        Per-run caller context/state (Agno-native, never mutates the harness):
+
+        - ``dependencies`` — merged over the construction-time ``dependencies``
+          and scoped to this run only. Every tool (via a ``run_context:
+          RunContext`` parameter Agno injects) and every custom dispatch adapter
+          (via :func:`get_current_run_context` / :func:`get_current_dependencies`)
+          reads it from one place. Left out of the model-facing context unless
+          ``add_dependencies_to_context`` is True, preserving the
+          "external variables never reach the model" guarantee.
+        - ``session_state`` — merged over the construction-time ``session_state``,
+          scoped to this run.
+        - ``add_dependencies_to_context`` / ``add_session_state_to_context`` /
+          ``knowledge_filters`` — forwarded to Agno's run for this call only.
+
+        Scoping is leak-free across concurrent and sequential runs on one harness:
+        the merged mappings are fresh copies Agno resolves into a per-run
+        ``RunContext``; the harness's defaults are read, never rewritten.
+        """
         self._check_context_budget()
 
         run_id = f"run_{uuid4().hex}"
@@ -4593,6 +4743,21 @@ class AgentHarness:
             )
             if isinstance(extra_metadata, dict):
                 agent_metadata.update(extra_metadata)
+
+            # Per-run caller context/state: merge over construction defaults and
+            # forward to Agno for this call only. Agno resolves these into a
+            # per-run RunContext without mutating the agent, so they're naturally
+            # scoped to the run — on success, on exception, and for streaming runs
+            # (the kwargs are captured by the iterator/generator returned below).
+            call_kwargs.update(
+                self._resolve_run_context_kwargs(
+                    dependencies=dependencies,
+                    session_state=session_state,
+                    add_dependencies_to_context=add_dependencies_to_context,
+                    add_session_state_to_context=add_session_state_to_context,
+                    knowledge_filters=knowledge_filters,
+                )
+            )
 
             # Per-run tool scoping: honor the active skill's allowed_tools and any
             # tool input-schema specialization for this run only.
@@ -4869,9 +5034,21 @@ class AgentHarness:
         metadata: dict[str, Any] | None = None,
         output_schema: type | None = None,
         tool_schema_overrides: dict[str, dict[str, Any]] | None = None,
+        dependencies: dict[str, Any] | None = None,
+        session_state: dict[str, Any] | None = None,
+        add_dependencies_to_context: bool | None = None,
+        add_session_state_to_context: bool | None = None,
+        knowledge_filters: dict[str, Any] | list[Any] | None = None,
         **kwargs,
     ) -> RunOutput | AsyncIterator[RunOutputEvent]:
-        """Async version of run()."""
+        """Async version of run().
+
+        Accepts the same per-run ``dependencies`` / ``session_state`` /
+        ``add_dependencies_to_context`` / ``add_session_state_to_context`` /
+        ``knowledge_filters`` kwargs as :meth:`run`, with identical merge-over-
+        construction-defaults and per-run scoping semantics (including the
+        streaming path).
+        """
         self._check_context_budget()
 
         run_id = f"run_{uuid4().hex}"
@@ -5029,6 +5206,18 @@ class AgentHarness:
             )
             if isinstance(extra_metadata, dict):
                 agent_metadata.update(extra_metadata)
+
+            # Per-run caller context/state: merge over construction defaults and
+            # forward to Agno for this call only (leak-free — see run()).
+            call_kwargs.update(
+                self._resolve_run_context_kwargs(
+                    dependencies=dependencies,
+                    session_state=session_state,
+                    add_dependencies_to_context=add_dependencies_to_context,
+                    add_session_state_to_context=add_session_state_to_context,
+                    knowledge_filters=knowledge_filters,
+                )
+            )
 
             # Per-run tool scoping: honor the active skill's allowed_tools and any
             # tool input-schema specialization for this run only.
@@ -5516,6 +5705,69 @@ class AgentHarness:
         if "session_id" not in data and "id" in data and data["id"] is not None:
             data["session_id"] = str(data["id"])
         return data
+
+    @property
+    def dependencies(self) -> dict[str, Any]:
+        """A copy of the harness's construction-time dependency default.
+
+        Per-run ``dependencies`` passed to :meth:`run`/:meth:`arun` are merged
+        over this mapping. To read the *active run's* dependencies from inside a
+        tool dispatch, use :func:`get_current_dependencies` instead.
+        """
+        return dict(self._dependencies)
+
+    def update_dependencies(self, dependencies: dict[str, Any]) -> dict[str, Any]:
+        """Update the harness's default dependency mapping at runtime.
+
+        Merges ``dependencies`` over the existing default and propagates the
+        result to the underlying Agno agent so subsequent runs (without a per-run
+        override) see it. Returns a copy of the new default.
+        """
+        self._dependencies.update(dependencies)
+        self._agent.dependencies = dict(self._dependencies) or None
+        return dict(self._dependencies)
+
+    def get_session_state(self, *, session_id: str | None = None) -> dict[str, Any]:
+        """Return Agno's persisted session_state for a session.
+
+        Proxies ``Agent.get_session_state``. Defaults to the harness's active
+        session when ``session_id`` is omitted.
+        """
+        return self._agent.get_session_state(session_id=session_id or self._active_session_id(None))
+
+    def update_session_state(
+        self,
+        session_state_updates: dict[str, Any],
+        *,
+        session_id: str | None = None,
+    ) -> str:
+        """Merge updates into Agno's persisted session_state for a session.
+
+        Proxies ``Agent.update_session_state``. Defaults to the harness's active
+        session when ``session_id`` is omitted.
+        """
+        return self._agent.update_session_state(
+            session_state_updates,
+            session_id=session_id or self._active_session_id(None),
+        )
+
+    async def aget_session_state(self, *, session_id: str | None = None) -> dict[str, Any]:
+        """Async variant of :meth:`get_session_state`."""
+        return await self._agent.aget_session_state(
+            session_id=session_id or self._active_session_id(None)
+        )
+
+    async def aupdate_session_state(
+        self,
+        session_state_updates: dict[str, Any],
+        *,
+        session_id: str | None = None,
+    ) -> str:
+        """Async variant of :meth:`update_session_state`."""
+        return await self._agent.aupdate_session_state(
+            session_state_updates,
+            session_id=session_id or self._active_session_id(None),
+        )
 
     def list_sessions(self, *, user_id: str | None = None, limit: int | None = 50) -> list[dict[str, Any]]:
         """

--- a/tests/test_run_context_scope.py
+++ b/tests/test_run_context_scope.py
@@ -1,0 +1,403 @@
+"""Tests for per-run dependencies/session_state and active RunContext exposure.
+
+Covers issue #52:
+  - Ask A: ``run``/``arun`` accept per-run ``dependencies`` / ``session_state``
+    (and context flags), merged over construction defaults and scoped per-run.
+  - Ask B: a stable way to read the active ``RunContext`` / ``dependencies`` from
+    a custom tool-dispatch path.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agnoclaw.config import HarnessConfig
+
+
+def _build_harness(tmp_path, **kwargs):
+    """Build an AgentHarness whose underlying Agno Agent is a MagicMock.
+
+    The mock captures the kwargs forwarded to ``Agent.run`` / ``Agent.arun`` so
+    tests can assert on the per-run context/state values.
+    """
+    from agnoclaw.agent import AgentHarness
+
+    mock_agent = MagicMock()
+    ctor_kwargs: dict = {}
+
+    def _agent_ctor(*args, **kw):
+        ctor_kwargs.update(kw)
+        mock_agent.system_message = kw.get("system_message")
+        mock_agent.session_id = kw.get("session_id")
+        return mock_agent
+
+    with patch("agnoclaw.agent.Agent", side_effect=_agent_ctor):
+        with patch("agnoclaw.agent._make_db", return_value=MagicMock()):
+            harness = AgentHarness(
+                workspace_dir=tmp_path,
+                config=HarnessConfig(),
+                **kwargs,
+            )
+    return harness, mock_agent, ctor_kwargs
+
+
+# ── _merge_run_mapping ───────────────────────────────────────────────────────
+
+
+def test_merge_run_mapping_override_wins():
+    from agnoclaw.agent import AgentHarness
+
+    merged = AgentHarness._merge_run_mapping({"a": 1, "b": 2}, {"b": 9, "c": 3})
+    assert merged == {"a": 1, "b": 9, "c": 3}
+
+
+def test_merge_run_mapping_empty_returns_none():
+    from agnoclaw.agent import AgentHarness
+
+    assert AgentHarness._merge_run_mapping({}, None) is None
+    assert AgentHarness._merge_run_mapping(None, None) is None
+    assert AgentHarness._merge_run_mapping({}, {}) is None
+
+
+def test_merge_run_mapping_base_only_passthrough():
+    from agnoclaw.agent import AgentHarness
+
+    assert AgentHarness._merge_run_mapping({"a": 1}, None) == {"a": 1}
+
+
+def test_merge_run_mapping_does_not_mutate_base():
+    from agnoclaw.agent import AgentHarness
+
+    base = {"a": 1}
+    AgentHarness._merge_run_mapping(base, {"b": 2})
+    assert base == {"a": 1}
+
+
+# ── Construction-time wiring ─────────────────────────────────────────────────
+
+
+def test_constructor_accepts_session_state(tmp_path):
+    _, _, ctor_kwargs = _build_harness(
+        tmp_path,
+        session_state={"counter": 0},
+        add_session_state_to_context=True,
+    )
+    assert ctor_kwargs["session_state"] == {"counter": 0}
+    assert ctor_kwargs["add_session_state_to_context"] is True
+
+
+def test_constructor_dependencies_forwarded(tmp_path):
+    _, _, ctor_kwargs = _build_harness(
+        tmp_path,
+        dependencies={"tenant_id": "acme"},
+    )
+    assert ctor_kwargs["dependencies"] == {"tenant_id": "acme"}
+
+
+# ── Per-run dependencies on run() ────────────────────────────────────────────
+
+
+def test_run_merges_per_run_dependencies(tmp_path):
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, dependencies={"tenant_id": "acme", "env": "prod"}
+    )
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run("hi", dependencies={"user_id": "u1", "env": "staging"})
+
+    forwarded = mock_agent.run.call_args.kwargs["dependencies"]
+    # per-run keys win; construction defaults preserved otherwise
+    assert forwarded == {"tenant_id": "acme", "env": "staging", "user_id": "u1"}
+
+
+def test_run_without_per_run_deps_does_not_forward(tmp_path):
+    """Default path leaves Agno to use the agent-level dependency default."""
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, dependencies={"tenant_id": "acme"}
+    )
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run("hi")
+
+    assert "dependencies" not in mock_agent.run.call_args.kwargs
+
+
+def test_run_per_run_session_state_merged(tmp_path):
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, session_state={"a": 1}
+    )
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run("hi", session_state={"b": 2})
+
+    assert mock_agent.run.call_args.kwargs["session_state"] == {"a": 1, "b": 2}
+
+
+def test_run_forwards_context_flags(tmp_path):
+    harness, mock_agent, _ = _build_harness(tmp_path)
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run(
+        "hi",
+        dependencies={"x": 1},
+        add_dependencies_to_context=True,
+        add_session_state_to_context=False,
+        knowledge_filters={"k": "v"},
+    )
+
+    kw = mock_agent.run.call_args.kwargs
+    assert kw["add_dependencies_to_context"] is True
+    assert kw["add_session_state_to_context"] is False
+    assert kw["knowledge_filters"] == {"k": "v"}
+
+
+def test_run_does_not_mutate_construction_dependencies(tmp_path):
+    """Sequential runs never leak per-run dependencies into the harness default."""
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, dependencies={"tenant_id": "acme"}
+    )
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    harness.run("first", dependencies={"req": "r1"})
+    harness.run("second", dependencies={"req": "r2"})
+
+    # The harness default is untouched...
+    assert harness._dependencies == {"tenant_id": "acme"}
+    # ...and each run forwarded only its own merged view.
+    first = mock_agent.run.call_args_list[0].kwargs["dependencies"]
+    second = mock_agent.run.call_args_list[1].kwargs["dependencies"]
+    assert first == {"tenant_id": "acme", "req": "r1"}
+    assert second == {"tenant_id": "acme", "req": "r2"}
+
+
+def test_run_exception_leaves_dependencies_intact(tmp_path):
+    from agnoclaw.runtime import HarnessError
+
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, dependencies={"tenant_id": "acme"}
+    )
+    mock_agent.run.side_effect = RuntimeError("boom")
+
+    with pytest.raises(HarnessError):
+        harness.run("hi", dependencies={"req": "r1"})
+
+    assert harness._dependencies == {"tenant_id": "acme"}
+
+
+def test_run_streaming_forwards_dependencies(tmp_path):
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, dependencies={"tenant_id": "acme"}
+    )
+    mock_agent.run.return_value = iter([])
+
+    stream = harness.run("hi", stream=True, dependencies={"req": "r1"})
+    list(stream)  # drain to execute the wrapped generator
+
+    forwarded = mock_agent.run.call_args.kwargs["dependencies"]
+    assert forwarded == {"tenant_id": "acme", "req": "r1"}
+
+
+# ── Per-run dependencies on arun() ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_arun_merges_per_run_dependencies(tmp_path):
+    harness, mock_agent, _ = _build_harness(
+        tmp_path, dependencies={"tenant_id": "acme"}
+    )
+    mock_agent.arun = AsyncMock(return_value=SimpleNamespace(content="ok"))
+
+    await harness.arun("hi", dependencies={"req": "r1"})
+
+    forwarded = mock_agent.arun.call_args.kwargs["dependencies"]
+    assert forwarded == {"tenant_id": "acme", "req": "r1"}
+    assert harness._dependencies == {"tenant_id": "acme"}
+
+
+# ── Ask B: active RunContext exposure ────────────────────────────────────────
+
+
+def test_get_current_run_context_default_none():
+    from agnoclaw.agent import get_current_run_context, get_current_dependencies
+
+    assert get_current_run_context() is None
+    assert get_current_dependencies() is None
+
+
+def test_active_run_context_set_and_cleared():
+    from agnoclaw.agent import (
+        AgentHarness,
+        get_current_run_context,
+        get_current_dependencies,
+    )
+
+    fc = SimpleNamespace()
+    run_context = SimpleNamespace(dependencies={"tenant_id": "acme"})
+
+    AgentHarness._set_active_run_context(fc, run_context)
+    try:
+        assert get_current_run_context() is run_context
+        assert get_current_dependencies() == {"tenant_id": "acme"}
+    finally:
+        AgentHarness._clear_active_run_context(fc)
+
+    assert get_current_run_context() is None
+    assert get_current_dependencies() is None
+
+
+def test_custom_dispatch_reads_dependencies():
+    """A custom dispatch adapter reads caller scope via the documented accessor."""
+    from agnoclaw.agent import (
+        AgentHarness,
+        get_current_dependencies,
+    )
+
+    seen: dict = {}
+
+    def custom_dispatch_adapter():
+        # No run_context parameter — reads from the contextvar instead.
+        seen.update(get_current_dependencies() or {})
+
+    fc = SimpleNamespace()
+    run_context = SimpleNamespace(dependencies={"tenant_id": "acme", "user_id": "u1"})
+    AgentHarness._set_active_run_context(fc, run_context)
+    try:
+        custom_dispatch_adapter()
+    finally:
+        AgentHarness._clear_active_run_context(fc)
+
+    assert seen == {"tenant_id": "acme", "user_id": "u1"}
+
+
+def test_get_current_dependencies_handles_missing():
+    from agnoclaw.agent import (
+        AgentHarness,
+        get_current_dependencies,
+    )
+
+    fc = SimpleNamespace()
+    # run_context without a dependencies attribute → None, no crash
+    AgentHarness._set_active_run_context(fc, SimpleNamespace())
+    try:
+        assert get_current_dependencies() is None
+    finally:
+        AgentHarness._clear_active_run_context(fc)
+
+
+# ── Harness-level dependency / session_state proxies ─────────────────────────
+
+
+def test_dependencies_property_returns_copy(tmp_path):
+    harness, _, _ = _build_harness(tmp_path, dependencies={"tenant_id": "acme"})
+    deps = harness.dependencies
+    assert deps == {"tenant_id": "acme"}
+    deps["mutated"] = True
+    # mutating the returned copy must not affect the harness default
+    assert harness.dependencies == {"tenant_id": "acme"}
+
+
+def test_update_dependencies_merges_and_propagates(tmp_path):
+    harness, mock_agent, _ = _build_harness(tmp_path, dependencies={"tenant_id": "acme"})
+
+    result = harness.update_dependencies({"region": "us-east"})
+
+    assert result == {"tenant_id": "acme", "region": "us-east"}
+    assert harness._dependencies == {"tenant_id": "acme", "region": "us-east"}
+    # propagated to the underlying agent for subsequent default-path runs
+    assert mock_agent.dependencies == {"tenant_id": "acme", "region": "us-east"}
+
+
+def test_get_session_state_proxies_agent(tmp_path):
+    harness, mock_agent, _ = _build_harness(tmp_path, session_id="s1")
+    mock_agent.get_session_state.return_value = {"counter": 3}
+
+    assert harness.get_session_state() == {"counter": 3}
+    assert mock_agent.get_session_state.call_args.kwargs["session_id"] == "s1"
+
+
+def test_update_session_state_proxies_agent(tmp_path):
+    harness, mock_agent, _ = _build_harness(tmp_path, session_id="s1")
+    mock_agent.update_session_state.return_value = "s1"
+
+    harness.update_session_state({"counter": 4}, session_id="other")
+
+    args, kwargs = mock_agent.update_session_state.call_args
+    assert args[0] == {"counter": 4}
+    assert kwargs["session_id"] == "other"
+
+
+@pytest.mark.asyncio
+async def test_aget_session_state_proxies_agent(tmp_path):
+    harness, mock_agent, _ = _build_harness(tmp_path, session_id="s1")
+    mock_agent.aget_session_state = AsyncMock(return_value={"counter": 9})
+
+    assert await harness.aget_session_state() == {"counter": 9}
+
+
+def test_real_tool_hook_exposes_run_context(tmp_path):
+    """Drive the actual attached tool pre/post hooks (not the static helpers).
+
+    Mirrors what Agno does: it calls ``function.pre_hook(fc=..., run_context=...)``
+    before the tool entrypoint and ``function.post_hook(...)`` after. The harness
+    wires those to set/clear the active RunContext so a custom dispatch adapter
+    can read caller scope mid-tool-call.
+    """
+    from agno.tools.function import Function
+    from agno.tools.toolkit import Toolkit
+
+    from agnoclaw.agent import (
+        AgentHarness,
+        get_current_dependencies,
+        get_current_run_context,
+        get_current_tool_runtime,
+    )
+
+    harness = AgentHarness(
+        workspace_dir=tmp_path,
+        config=HarnessConfig(),
+        include_default_tools=True,
+    )
+
+    # Find a default-tool Function that has the harness runtime hooks attached.
+    target = None
+    for tool in harness._agent.tools:
+        if isinstance(tool, Toolkit):
+            for fn in tool.functions.values():
+                if getattr(fn.pre_hook, "_agnoclaw_runtime_pre", False):
+                    target = fn
+                    break
+        elif isinstance(tool, Function) and getattr(
+            getattr(tool, "pre_hook", None), "_agnoclaw_runtime_pre", False
+        ):
+            target = tool
+        if target is not None:
+            break
+    assert target is not None, "expected a tool with runtime hooks attached"
+
+    fc = SimpleNamespace(
+        function=SimpleNamespace(name=target.name),
+        arguments={},
+        result=None,
+        error=None,
+    )
+    run_context = SimpleNamespace(
+        run_id="run_x",
+        session_id="s",
+        user_id="u",
+        metadata={},
+        dependencies={"tenant_id": "acme", "user_id": "u1"},
+    )
+
+    target.pre_hook(fc=fc, run_context=run_context)
+    try:
+        assert get_current_run_context() is run_context
+        assert get_current_dependencies() == {"tenant_id": "acme", "user_id": "u1"}
+        # Also surfaced through the existing tool-runtime accessor.
+        runtime = get_current_tool_runtime()
+        assert runtime is not None and runtime.get("run_context") is run_context
+    finally:
+        target.post_hook(fc=fc, run_context=run_context)
+
+    assert get_current_run_context() is None
+    assert get_current_dependencies() is None

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "agnoclaw"
-version = "0.7.5"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },


### PR DESCRIPTION
Closes #52.

Makes Agno's `RunContext` / `dependencies` the single contract for caller-supplied, LLM-hidden context: set scope once per run, read it from one place in every tool and every custom dispatch adapter.

## Ask A — per-run `dependencies` / `session_state` on `run()` / `arun()`
- `run`/`arun` accept `dependencies`, `session_state`, `add_dependencies_to_context`, `add_session_state_to_context`, `knowledge_filters`.
- `dependencies` / `session_state` **merge over** the construction-time defaults and are scoped to that run. Agno resolves them into a per-run `RunContext` **without mutating the agent**, so scoping is leak-free across concurrent and sequential runs — on success, on exception, and for streaming runs (the merged copy is captured by the iterator/generator). The harness defaults are read, never rewritten.
- Added construction-time `session_state` / `add_session_state_to_context` to mirror the existing `dependencies` wiring.

## Ask B — read the active `RunContext` from a custom dispatch path
- `_CURRENT_RUN_CONTEXT` contextvar set for the duration of each tool dispatch, with public `get_current_run_context()` / `get_current_dependencies()` accessors.
- `run_context` also surfaced in the tool-runtime dict via `get_current_tool_runtime()`.

## Broader: full Agno context/state surface on the harness
- `get_session_state` / `update_session_state` (+ async) proxies, a `dependencies` property, and `update_dependencies()` to revise the default at runtime.

## Acceptance
- [x] `run`/`arun` accept per-run `dependencies` (and `session_state`), merged over defaults, restored after the run (success, exception, streaming).
- [x] Documented, stable way to read the active `RunContext` / `dependencies` from custom dispatch.
- [x] Concurrent/sequential runs don't leak per-run dependencies.
- [x] Example: `examples/per_run_dependencies.py` — a tool and a custom dispatch adapter both read `dependencies={"tenant_id": ...}` from the run context.

## Tests
24 new tests (`tests/test_run_context_scope.py`): merge semantics, leak-free restore, streaming, the real attached tool-hook path, and custom-dispatch reads. Full suite: 787 passed, coverage 80.65% (gate 80%). Version 0.8.0 → 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)