### PR TITLE
Per-run tool argument binding — partial application (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,38 @@ state = harness.get_session_state(session_id="s1")
 
 See `examples/per_run_dependencies.py` for a runnable end-to-end demo.
 
+### v0.10 features (per-run tool argument binding — partial application)
+
+Bind specific tool arguments for a single run: the bound args are **removed from
+the schema the model sees** AND **supplied at dispatch** (caller-wins; the model
+never sees or sets them). Conceptually `functools.partial(tool, **bound)` for a
+tool, scoped to one run — the pre-bound values can be chosen per run (resolved
+from the active skill, the request scope, etc.). Composes with
+`tool_schema_overrides` (re-type the remaining visible args) and a skill's
+`allowed_tools`; restored after the run (success, exception, streaming), so a
+later run without the binding sees the full signature.
+
+```python
+from agno.tools import tool
+from agnoclaw import AgentHarness
+
+@tool
+def save_artifact(name: str, kind: str, schema: str, content: str) -> str:
+    ...
+
+harness = AgentHarness(tools=[save_artifact])
+
+# This run: the model only sees `name` and `content`; kind/schema are pre-bound
+# and injected at dispatch.
+harness.run(
+    "Create and save a note.",
+    tool_arg_bindings={"save_artifact": {"kind": "note", "schema": "v1"}},
+)
+```
+
+A skill can also declare static bindings via `tool-arg-bindings` frontmatter;
+per-run values passed to `run`/`arun` win. See `examples/tool_arg_bindings.py`.
+
 See [`cookbook/`](cookbook/) for complete runnable examples of each feature.
 
 ---

--- a/examples/tool_arg_bindings.py
+++ b/examples/tool_arg_bindings.py
@@ -1,0 +1,53 @@
+"""
+Per-run tool argument binding — partial application for a tool (issue #54).
+
+Bind specific tool arguments for a single run: the bound args are removed from
+the schema the model sees AND supplied at dispatch. Effectively the model is
+handed `functools.partial(tool, **bound)` for that run, with the pre-bound
+values chosen per run (e.g. resolved from the active skill or per-request scope).
+
+Composes with `tool_schema_overrides` (re-type the remaining visible args) and a
+skill's `allowed_tools`. Restored after the run; a later run without the binding
+sees the full signature.
+
+Run: uv run python examples/tool_arg_bindings.py
+"""
+
+from _utils import detect_model
+from agno.tools import tool
+
+from agnoclaw import AgentHarness
+
+
+@tool
+def save_artifact(name: str, kind: str, schema: str, content: str) -> str:
+    """Persist an artifact.
+
+    Args:
+      name: human label for the artifact
+      kind: artifact kind (bound per run)
+      schema: payload schema id (bound per run)
+      content: the artifact body the model produces
+    """
+    return f"saved {name} [{kind}/{schema}] ({len(content)} chars)"
+
+
+agent = AgentHarness(
+    name="binder",
+    model=detect_model(),
+    tools=[save_artifact],
+)
+
+# This run: the model only sees `name` and `content`; `kind`/`schema` are
+# pre-bound and injected at dispatch (it never sees or sets them).
+agent.print_response(
+    "Create a short note artifact named 'welcome' and save it.",
+    tool_arg_bindings={"save_artifact": {"kind": "note", "schema": "v1"}},
+    stream=True,
+)
+
+# A later run without the binding sees the full four-arg signature again.
+agent.print_response(
+    "Save an artifact named 'report' of kind 'doc' with schema 'v2'.",
+    stream=True,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agnoclaw"
-version = "0.9.0"
+version = "0.10.0"
 description = "A hackable, model-agnostic agent harness built on Agno — with Claude Code's prompt wisdom, OpenClaw's UX patterns, and full Python extensibility"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agnoclaw/__init__.py
+++ b/src/agnoclaw/__init__.py
@@ -170,4 +170,4 @@ __all__ = [
     "trust_pack",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/agnoclaw/agent.py
+++ b/src/agnoclaw/agent.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import functools
 import inspect
 import json
 import logging
@@ -537,27 +538,43 @@ class _ToolScope:
     """A reversible, per-run view over an Agno agent's toolset.
 
     Captures the agent's original ``tools`` list and the original parameter
-    schema of any tool whose schema is overridden, so the run can:
+    schema / entrypoint of any tool the run reshapes, so the run can:
 
-      * hide tools the active skill did not allow (``allowed_tools``), and
-      * advertise a specialized input schema for named tools,
+      * hide tools the active skill did not allow (``allowed_tools``),
+      * advertise a specialized input schema for named tools, and
+      * bind specific tool arguments for the run — partial application: the
+        bound args are removed from the advertised schema and supplied at
+        dispatch via a per-run ``functools.partial`` entrypoint,
 
     then restore everything exactly on exit. No persisted mutation survives a
     run: ``restore()`` is idempotent and always returns the agent to its
     construction-time toolset.
     """
 
-    __slots__ = ("_agent", "_original_tools", "_param_backups", "_restored")
+    __slots__ = (
+        "_agent",
+        "_original_tools",
+        "_param_backups",
+        "_entrypoint_backups",
+        "_restored",
+    )
 
     def __init__(self, agent: Any, original_tools: Any) -> None:
         self._agent = agent
         self._original_tools = original_tools
         # list of (function_object, original_parameters_dict)
         self._param_backups: list[tuple[Any, dict[str, Any]]] = []
+        # list of (function_object, original_entrypoint, original_skip_flag)
+        self._entrypoint_backups: list[tuple[Any, Any, Any]] = []
         self._restored = False
 
     def record_param_override(self, function: Any, original_parameters: dict[str, Any]) -> None:
         self._param_backups.append((function, original_parameters))
+
+    def record_entrypoint_binding(
+        self, function: Any, original_entrypoint: Any, original_skip: Any
+    ) -> None:
+        self._entrypoint_backups.append((function, original_entrypoint, original_skip))
 
     def restore(self) -> None:
         if self._restored:
@@ -565,6 +582,9 @@ class _ToolScope:
         self._restored = True
         self._agent.tools = self._original_tools
         # Restore in reverse so repeated overrides of the same object unwind cleanly.
+        for function, original_entrypoint, original_skip in reversed(self._entrypoint_backups):
+            function.entrypoint = original_entrypoint
+            function.skip_entrypoint_processing = original_skip
         for function, original_parameters in reversed(self._param_backups):
             function.parameters = original_parameters
 
@@ -1172,6 +1192,7 @@ class AgentHarness:
         *,
         allowed: list[str] | None = None,
         schema_overrides: dict[str, dict[str, Any]] | None = None,
+        arg_bindings: dict[str, dict[str, Any]] | None = None,
     ) -> _ToolScope | None:
         """Scope the agent's toolset for a single run, returning a restore token.
 
@@ -1179,7 +1200,10 @@ class AgentHarness:
         names (functions nested in toolkits are surfaced individually so a single
         function can be exposed without its sibling tools). ``schema_overrides``
         maps a tool name → a JSON Schema dict to advertise as that tool's input
-        schema for the run. Both are reverted by :meth:`_restore_tool_scope`.
+        schema for the run. ``arg_bindings`` maps a tool name → {arg: value} to
+        bind for the run (partial application): the bound args are removed from
+        the advertised schema *and* supplied at dispatch. All three are reverted
+        by :meth:`_restore_tool_scope`.
 
         Returns ``None`` when there is nothing to scope, so callers pay no cost on
         the common (no-skill / unrestricted) path.
@@ -1199,10 +1223,17 @@ class AgentHarness:
           ``additionalProperties: False`` (see ``Function.process_entrypoint``).
           Overrides reliably control nested shapes, types, and descriptions; the
           top-level required set follows the entrypoint.
+        * For ``arg_bindings`` the entrypoint is replaced with a
+          ``functools.partial`` carrying the bound values and
+          ``skip_entrypoint_processing`` is set, so Agno keeps the stripped schema
+          verbatim. This sidesteps the ``required``-recompute above: a bound arg
+          that has no default would otherwise be re-added to ``required`` while
+          absent from ``properties`` (a dangling required entry).
         """
         allowed_present = allowed is not None
         overrides_present = bool(schema_overrides)
-        if not allowed_present and not overrides_present:
+        bindings_present = bool(arg_bindings)
+        if not allowed_present and not overrides_present and not bindings_present:
             return None
 
         original_tools = self._agent.tools
@@ -1230,8 +1261,13 @@ class AgentHarness:
         else:
             working = current
 
+        by_name = (
+            self._resolve_function_objects(working)
+            if overrides_present or bindings_present
+            else {}
+        )
+
         if overrides_present:
-            by_name = self._resolve_function_objects(working)
             for override_name, schema in (schema_overrides or {}).items():
                 target_fn = by_name.get(str(override_name))
                 if target_fn is None or not hasattr(target_fn, "parameters"):
@@ -1241,7 +1277,79 @@ class AgentHarness:
                 # Agno's per-run processing (which sets additionalProperties/required).
                 target_fn.parameters = copy.deepcopy(schema)
 
+        if bindings_present:
+            for bind_name, values in (arg_bindings or {}).items():
+                if not values:
+                    continue
+                target_fn = by_name.get(str(bind_name))
+                if target_fn is None or not hasattr(target_fn, "parameters"):
+                    continue
+                original_entrypoint = getattr(target_fn, "entrypoint", None)
+                if original_entrypoint is None:
+                    continue
+                self._bind_tool_args(scope, target_fn, dict(values))
+
         return scope
+
+    @staticmethod
+    def _schema_has_properties(schema: Any) -> bool:
+        return isinstance(schema, dict) and bool(schema.get("properties"))
+
+    def _bind_tool_args(
+        self,
+        scope: _ToolScope,
+        target_fn: Any,
+        values: dict[str, Any],
+    ) -> None:
+        """Partially apply ``values`` to ``target_fn`` for the duration of a run.
+
+        Removes the bound argument names from the advertised input schema and
+        replaces the entrypoint with a ``functools.partial`` so the bound values
+        are supplied at dispatch and never exposed to (or settable by) the model.
+        Originals are recorded on ``scope`` for restoration.
+        """
+        original_entrypoint = target_fn.entrypoint
+        original_skip = getattr(target_fn, "skip_entrypoint_processing", False)
+
+        # Resolve the baseline schema to strip from. A tool whose schema was
+        # already specialized this run (schema_overrides) carries it on
+        # ``parameters``; an untouched toolkit tool has an empty default schema
+        # until Agno processes it per-run, so generate it on a throwaway copy.
+        current_params = target_fn.parameters
+        if self._schema_has_properties(current_params):
+            baseline = copy.deepcopy(current_params)
+        else:
+            baseline = None
+            try:
+                probe = target_fn.model_copy(deep=True)
+                probe.skip_entrypoint_processing = False
+                probe.process_entrypoint()
+                if self._schema_has_properties(probe.parameters):
+                    baseline = copy.deepcopy(probe.parameters)
+            except Exception:
+                logger.debug("Could not derive schema for tool binding", exc_info=True)
+            if baseline is None:
+                baseline = copy.deepcopy(current_params) if isinstance(current_params, dict) else {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                }
+
+        props = baseline.get("properties")
+        if isinstance(props, dict):
+            for arg in values:
+                props.pop(arg, None)
+        required = baseline.get("required")
+        if isinstance(required, list):
+            baseline["required"] = [name for name in required if name not in values]
+
+        scope.record_param_override(target_fn, current_params)
+        scope.record_entrypoint_binding(target_fn, original_entrypoint, original_skip)
+        target_fn.parameters = baseline
+        target_fn.entrypoint = functools.partial(original_entrypoint, **values)
+        # Keep the stripped schema verbatim — Agno's process_entrypoint would
+        # otherwise recompute `required` from the (now partial) signature.
+        target_fn.skip_entrypoint_processing = True
 
     @staticmethod
     def _restore_tool_scope(scope: _ToolScope | None) -> None:
@@ -1253,15 +1361,23 @@ class AgentHarness:
     def _skill_tool_scope_args(
         skill_obj: Any,
         tool_schema_overrides: dict[str, dict[str, Any]] | None,
-    ) -> tuple[list[str] | None, dict[str, dict[str, Any]] | None]:
-        """Resolve (allowed, schema_overrides) for the inline-skill scope.
+        tool_arg_bindings: dict[str, dict[str, Any]] | None = None,
+    ) -> tuple[
+        list[str] | None,
+        dict[str, dict[str, Any]] | None,
+        dict[str, dict[str, Any]] | None,
+    ]:
+        """Resolve (allowed, schema_overrides, arg_bindings) for the inline scope.
 
         ``allowed_tools`` from the skill restricts the toolset; explicit
         ``tool_schema_overrides`` passed to run/arun take precedence over the
-        skill's declared ``tool_schemas``.
+        skill's declared ``tool_schemas``. ``tool_arg_bindings`` are per-run
+        partial-application values (their values are run-scoped, so they come
+        from the call site; any skill-declared bindings are merged under them).
         """
         allowed: list[str] | None = None
         skill_schemas: dict[str, dict[str, Any]] = {}
+        skill_bindings: dict[str, dict[str, Any]] = {}
         if skill_obj is not None:
             meta = getattr(skill_obj, "meta", None)
             if meta is not None:
@@ -1269,8 +1385,11 @@ class AgentHarness:
                     allowed = list(meta.allowed_tools)
                 if getattr(meta, "tool_schemas", None):
                     skill_schemas = dict(meta.tool_schemas)
+                if getattr(meta, "tool_arg_bindings", None):
+                    skill_bindings = dict(meta.tool_arg_bindings)
         overrides = {**skill_schemas, **(tool_schema_overrides or {})}
-        return allowed, (overrides or None)
+        bindings = {**skill_bindings, **(tool_arg_bindings or {})}
+        return allowed, (overrides or None), (bindings or None)
 
     @staticmethod
     def _merge_run_mapping(
@@ -4512,6 +4631,7 @@ class AgentHarness:
         metadata: dict[str, Any] | None = None,
         output_schema: type | None = None,
         tool_schema_overrides: dict[str, dict[str, Any]] | None = None,
+        tool_arg_bindings: dict[str, dict[str, Any]] | None = None,
         dependencies: dict[str, Any] | None = None,
         session_state: dict[str, Any] | None = None,
         add_dependencies_to_context: bool | None = None,
@@ -4520,6 +4640,14 @@ class AgentHarness:
         **kwargs,
     ) -> RunOutput | Iterator[RunOutputEvent]:
         """Run the agent on a message.
+
+        ``tool_arg_bindings`` partially applies tool arguments for this run only
+        (``{tool_name: {arg: value}}``): the bound args are removed from the
+        schema the model sees AND supplied at dispatch (caller-wins, the model
+        never sets them) — `functools.partial` for a tool, scoped to the run.
+        Composes with ``tool_schema_overrides`` (re-typing the remaining visible
+        args) and a skill's ``allowed_tools``; restored after the run (on
+        success, on exception, and for streaming runs).
 
         Per-run caller context/state (Agno-native, never mutates the harness):
 
@@ -4769,12 +4897,14 @@ class AgentHarness:
             # its lifetime to generator execution. Applying it here for a stream
             # would leak permanently if the caller never drains it, because an
             # unstarted generator's finally never runs.
-            scope_allowed, scope_overrides = self._skill_tool_scope_args(
-                scoped_skill_obj, tool_schema_overrides
+            scope_allowed, scope_overrides, scope_bindings = self._skill_tool_scope_args(
+                scoped_skill_obj, tool_schema_overrides, tool_arg_bindings
             )
             if not stream:
                 tool_scope = self._apply_tool_scope(
-                    allowed=scope_allowed, schema_overrides=scope_overrides
+                    allowed=scope_allowed,
+                    schema_overrides=scope_overrides,
+                    arg_bindings=scope_bindings,
                 )
 
             result = self._agent.run(
@@ -4804,7 +4934,9 @@ class AgentHarness:
                         # generator's. Agno resolves tools lazily during iteration,
                         # so this is active before the first model request.
                         stream_scope = self._apply_tool_scope(
-                            allowed=scope_allowed, schema_overrides=scope_overrides
+                            allowed=scope_allowed,
+                            schema_overrides=scope_overrides,
+                            arg_bindings=scope_bindings,
                         )
                         for event in result:
                             source_event = self._event_name(event) or None
@@ -5034,6 +5166,7 @@ class AgentHarness:
         metadata: dict[str, Any] | None = None,
         output_schema: type | None = None,
         tool_schema_overrides: dict[str, dict[str, Any]] | None = None,
+        tool_arg_bindings: dict[str, dict[str, Any]] | None = None,
         dependencies: dict[str, Any] | None = None,
         session_state: dict[str, Any] | None = None,
         add_dependencies_to_context: bool | None = None,
@@ -5043,11 +5176,11 @@ class AgentHarness:
     ) -> RunOutput | AsyncIterator[RunOutputEvent]:
         """Async version of run().
 
-        Accepts the same per-run ``dependencies`` / ``session_state`` /
-        ``add_dependencies_to_context`` / ``add_session_state_to_context`` /
-        ``knowledge_filters`` kwargs as :meth:`run`, with identical merge-over-
-        construction-defaults and per-run scoping semantics (including the
-        streaming path).
+        Accepts the same per-run ``tool_arg_bindings`` / ``dependencies`` /
+        ``session_state`` / ``add_dependencies_to_context`` /
+        ``add_session_state_to_context`` / ``knowledge_filters`` kwargs as
+        :meth:`run`, with identical merge-over-construction-defaults and per-run
+        scoping semantics (including the streaming path).
         """
         self._check_context_budget()
 
@@ -5231,8 +5364,8 @@ class AgentHarness:
             # generator execution. Applying it before returning the generator would
             # leak permanently if the caller never drains it (an unstarted
             # generator's finally never runs).
-            scope_allowed, scope_overrides = self._skill_tool_scope_args(
-                scoped_skill_obj, tool_schema_overrides
+            scope_allowed, scope_overrides, scope_bindings = self._skill_tool_scope_args(
+                scoped_skill_obj, tool_schema_overrides, tool_arg_bindings
             )
 
             agno_call = self._agent.arun(
@@ -5253,7 +5386,9 @@ class AgentHarness:
             else:
                 # Coroutine: the whole loop runs on await — scope it here.
                 tool_scope = self._apply_tool_scope(
-                    allowed=scope_allowed, schema_overrides=scope_overrides
+                    allowed=scope_allowed,
+                    schema_overrides=scope_overrides,
+                    arg_bindings=scope_bindings,
                 )
                 result = await agno_call
 
@@ -5273,7 +5408,9 @@ class AgentHarness:
                         # generator's. Agno resolves tools lazily during iteration,
                         # so this is active before the first model request.
                         stream_scope = self._apply_tool_scope(
-                            allowed=scope_allowed, schema_overrides=scope_overrides
+                            allowed=scope_allowed,
+                            schema_overrides=scope_overrides,
+                            arg_bindings=scope_bindings,
                         )
                         async for event in result:
                             source_event = self._event_name(event) or None

--- a/src/agnoclaw/skills/loader.py
+++ b/src/agnoclaw/skills/loader.py
@@ -88,6 +88,11 @@ class SkillMeta:
     # input shape (restored afterward), so a generic "save"-style tool can expose
     # the exact typed payload the skill expects for that turn.
     tool_schemas: dict[str, dict] = field(default_factory=dict)
+    # Per-run tool argument binding (partial application): tool name → {arg: value}.
+    # During a run with this skill, the named args are removed from the schema the
+    # model sees and supplied at dispatch (restored afterward). Usually set at the
+    # call site (values are run-scoped), but a skill may declare static bindings.
+    tool_arg_bindings: dict[str, dict] = field(default_factory=dict)
     model: Optional[str] = None
     context: Optional[str] = None       # "fork" for isolated subagent
     argument_hint: Optional[str] = None
@@ -241,6 +246,27 @@ def load_skill_from_path(skill_md_path: Path) -> Optional[Skill]:
                     name, tool_name,
                 )
 
+    # Parse per-run tool argument bindings (tool name → {arg: value}).
+    tool_arg_bindings_raw = metadata.get(
+        "tool-arg-bindings", metadata.get("tool_arg_bindings", {})
+    )
+    if isinstance(tool_arg_bindings_raw, str):
+        try:
+            import json as _json
+            tool_arg_bindings_raw = _json.loads(tool_arg_bindings_raw)
+        except Exception:
+            tool_arg_bindings_raw = {}
+    tool_arg_bindings: dict[str, dict] = {}
+    if isinstance(tool_arg_bindings_raw, dict):
+        for tool_name, binding in tool_arg_bindings_raw.items():
+            if isinstance(binding, dict):
+                tool_arg_bindings[str(tool_name)] = binding
+            else:
+                logger.warning(
+                    "Skill '%s': ignoring non-object tool arg binding for %r",
+                    name, tool_name,
+                )
+
     # Parse OpenClaw gating metadata.
     # Accepts aliases: metadata.openclaw, metadata.clawdbot, metadata.clawdis
     raw_meta = metadata.get("metadata") or {}
@@ -295,6 +321,7 @@ def load_skill_from_path(skill_md_path: Path) -> Optional[Skill]:
         ),
         allowed_tools=allowed_tools,
         tool_schemas=tool_schemas,
+        tool_arg_bindings=tool_arg_bindings,
         model=metadata.get("model"),
         context=metadata.get("context"),
         argument_hint=metadata.get("argument-hint", metadata.get("argument_hint")),

--- a/tests/test_tool_arg_bindings.py
+++ b/tests/test_tool_arg_bindings.py
@@ -1,0 +1,279 @@
+"""Tests for per-run tool argument binding (partial application) — issue #54.
+
+A binding removes the named args from the schema the model sees AND supplies
+them at dispatch (via a per-run ``functools.partial``), restoring both on exit.
+"""
+
+import logging
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agno.tools import tool
+from agno.tools.function import Function
+
+from agnoclaw.config import HarnessConfig
+
+
+@tool
+def save_thing(name: str, kind: str, schema: str, note: str = "") -> str:
+    """Save a thing.
+
+    Args:
+      name: the name
+      kind: the kind
+      schema: the schema
+      note: optional note
+    """
+    return f"{name}/{kind}/{schema}/{note}"
+
+
+def _harness(tools=None, **kwargs):
+    from agnoclaw.agent import AgentHarness
+
+    return AgentHarness(
+        workspace_dir=tempfile.mkdtemp(),
+        config=HarnessConfig(),
+        include_default_tools=False,
+        tools=tools if tools is not None else [save_thing],
+        **kwargs,
+    )
+
+
+def _live_function(harness, name):
+    for tool_obj in harness._agent.tools:
+        if isinstance(tool_obj, Function) and tool_obj.name == name:
+            return tool_obj
+    return None
+
+
+def _model_facing(fn):
+    """Resolve the schema + entrypoint the model/dispatch would see for ``fn``.
+
+    Mirrors Agno's per-run tool resolution: deep-copy the function and run
+    ``process_entrypoint`` (which keeps a stripped schema verbatim only because
+    the binding sets ``skip_entrypoint_processing``).
+    """
+    logging.disable(logging.WARNING)
+    try:
+        copied = fn.model_copy(deep=True)
+        copied.process_entrypoint()
+        return copied
+    finally:
+        logging.disable(logging.NOTSET)
+
+
+# ── Schema hiding + dispatch injection ───────────────────────────────────────
+
+
+def test_bound_args_absent_from_schema_and_present_at_dispatch():
+    harness = _harness()
+    scope = harness._apply_tool_scope(
+        arg_bindings={"save_thing": {"kind": "alpha", "schema": "beta"}}
+    )
+    try:
+        fn = _live_function(harness, "save_thing")
+        model_fn = _model_facing(fn)
+
+        # bound args removed from BOTH properties and required (no dangling entry)
+        assert sorted(model_fn.parameters["properties"]) == ["name", "note"]
+        assert model_fn.parameters.get("required") == ["name"]
+
+        # bound values supplied at dispatch; model only provides visible args
+        assert model_fn.entrypoint(name="N", note="Z") == "N/alpha/beta/Z"
+    finally:
+        scope.restore()
+
+
+def test_binding_restored_after_run_sees_full_signature():
+    harness = _harness()
+    fn = _live_function(harness, "save_thing")
+    original_entrypoint = fn.entrypoint
+
+    scope = harness._apply_tool_scope(
+        arg_bindings={"save_thing": {"kind": "alpha", "schema": "beta"}}
+    )
+    scope.restore()
+
+    # entrypoint + skip flag restored, and a fresh resolution shows all args
+    assert fn.entrypoint is original_entrypoint
+    assert fn.skip_entrypoint_processing is False
+    model_fn = _model_facing(fn)
+    assert sorted(model_fn.parameters["properties"]) == ["kind", "name", "note", "schema"]
+
+
+def test_apply_tool_scope_returns_none_when_nothing_to_scope():
+    harness = _harness()
+    assert harness._apply_tool_scope() is None
+    assert harness._apply_tool_scope(arg_bindings={}) is None
+    assert harness._apply_tool_scope(arg_bindings={"save_thing": {}}) is not None  # tool present but empty values → scope created, no-op binding
+
+
+def test_binding_unknown_tool_is_ignored():
+    harness = _harness()
+    scope = harness._apply_tool_scope(arg_bindings={"nope": {"a": 1}})
+    try:
+        # nothing to bind, but a scope object is still returned; no crash
+        assert scope is not None
+    finally:
+        scope.restore()
+
+
+# ── Composition ──────────────────────────────────────────────────────────────
+
+
+def test_binding_composes_with_allowed_tools():
+    @tool
+    def other(x: str) -> str:
+        "Other.\n\nArgs:\n  x: x"
+        return x
+
+    harness = _harness(tools=[save_thing, other])
+    scope = harness._apply_tool_scope(
+        allowed=["save_thing"],
+        arg_bindings={"save_thing": {"kind": "k", "schema": "s"}},
+    )
+    try:
+        names = {getattr(t, "name", None) for t in harness._agent.tools}
+        assert names == {"save_thing"}  # allow-scoped
+        fn = _live_function(harness, "save_thing")
+        model_fn = _model_facing(fn)
+        assert sorted(model_fn.parameters["properties"]) == ["name", "note"]
+        assert model_fn.entrypoint(name="N") == "N/k/s/"
+    finally:
+        scope.restore()
+
+
+def test_binding_composes_with_schema_overrides():
+    # Override reshapes the VISIBLE args; binding strips the bound ones from it.
+    override = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "renamed"},
+            "kind": {"type": "string"},
+            "schema": {"type": "string"},
+            "note": {"type": "string"},
+        },
+        "required": ["name", "kind", "schema"],
+    }
+    harness = _harness()
+    scope = harness._apply_tool_scope(
+        schema_overrides={"save_thing": override},
+        arg_bindings={"save_thing": {"kind": "k", "schema": "s"}},
+    )
+    try:
+        fn = _live_function(harness, "save_thing")
+        # binding stripped kind/schema from the override-provided schema
+        assert sorted(fn.parameters["properties"]) == ["name", "note"]
+        assert fn.parameters.get("required") == ["name"]
+        assert fn.parameters["properties"]["name"]["description"] == "renamed"
+        assert fn.entrypoint(name="N", note="Z") == "N/k/s/Z"
+    finally:
+        scope.restore()
+    # fully restored
+    assert sorted(_model_facing(fn).parameters["properties"]) == ["kind", "name", "note", "schema"]
+
+
+# ── run()/arun() threading ───────────────────────────────────────────────────
+
+
+def _mock_agent_harness():
+    from agnoclaw.agent import AgentHarness
+
+    mock_agent = MagicMock()
+
+    def _ctor(*a, **kw):
+        mock_agent.system_message = kw.get("system_message")
+        mock_agent.session_id = kw.get("session_id")
+        mock_agent.tools = kw.get("tools")
+        return mock_agent
+
+    with patch("agnoclaw.agent.Agent", side_effect=_ctor):
+        with patch("agnoclaw.agent._make_db", return_value=MagicMock()):
+            harness = AgentHarness(
+                workspace_dir=tempfile.mkdtemp(),
+                config=HarnessConfig(),
+                include_default_tools=False,
+                tools=[save_thing],
+            )
+    return harness, mock_agent
+
+
+def test_run_forwards_bindings_to_apply_tool_scope():
+    harness, mock_agent = _mock_agent_harness()
+    mock_agent.run.return_value = SimpleNamespace(content="ok")
+
+    with patch.object(harness, "_apply_tool_scope", wraps=harness._apply_tool_scope) as spy:
+        harness.run("hi", tool_arg_bindings={"save_thing": {"kind": "k"}})
+
+    # the non-streaming path applies the scope once with our bindings
+    assert any(
+        call.kwargs.get("arg_bindings") == {"save_thing": {"kind": "k"}}
+        for call in spy.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_arun_forwards_bindings_to_apply_tool_scope():
+    from unittest.mock import AsyncMock
+
+    harness, mock_agent = _mock_agent_harness()
+    mock_agent.arun = AsyncMock(return_value=SimpleNamespace(content="ok"))
+
+    with patch.object(harness, "_apply_tool_scope", wraps=harness._apply_tool_scope) as spy:
+        await harness.arun("hi", tool_arg_bindings={"save_thing": {"schema": "s"}})
+
+    assert any(
+        call.kwargs.get("arg_bindings") == {"save_thing": {"schema": "s"}}
+        for call in spy.call_args_list
+    )
+
+
+# ── _skill_tool_scope_args resolution ────────────────────────────────────────
+
+
+def test_skill_tool_scope_args_returns_bindings_triple():
+    from agnoclaw.agent import AgentHarness
+
+    allowed, overrides, bindings = AgentHarness._skill_tool_scope_args(
+        None, None, {"save_thing": {"kind": "k"}}
+    )
+    assert allowed is None and overrides is None
+    assert bindings == {"save_thing": {"kind": "k"}}
+
+
+def test_skill_declared_bindings_merge_under_per_run():
+    from agnoclaw.agent import AgentHarness
+
+    skill = SimpleNamespace(
+        meta=SimpleNamespace(
+            allowed_tools=None,
+            tool_schemas=None,
+            tool_arg_bindings={"save_thing": {"kind": "from_skill"}},
+        )
+    )
+    # per-run binding for the same tool wins
+    _, _, bindings = AgentHarness._skill_tool_scope_args(
+        skill, None, {"save_thing": {"kind": "from_run"}}
+    )
+    assert bindings == {"save_thing": {"kind": "from_run"}}
+
+
+def test_skill_meta_parses_tool_arg_bindings(tmp_path):
+    from agnoclaw.skills.loader import load_skill_from_path
+
+    skill_dir = tmp_path / "binder"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: binder\n"
+        "description: test\n"
+        'tool-arg-bindings: {"save_thing": {"kind": "x"}}\n'
+        "---\n\n"
+        "Body.\n"
+    )
+    skill = load_skill_from_path(skill_dir / "SKILL.md")
+    assert skill is not None
+    assert skill.meta.tool_arg_bindings == {"save_thing": {"kind": "x"}}

--- a/tests/test_tool_scoping.py
+++ b/tests/test_tool_scoping.py
@@ -247,7 +247,7 @@ def test_scope_args_reads_skill_meta(harness: AgentHarness) -> None:
         tool_schemas={"save_artifact": CONTENT_SCHEMA},
     )
     skill = Skill(meta=meta, content="x", path=Path("x"))
-    allowed, overrides = harness._skill_tool_scope_args(skill, None)
+    allowed, overrides, _bindings = harness._skill_tool_scope_args(skill, None)
     assert allowed == ["save_artifact"]
     assert overrides == {"save_artifact": CONTENT_SCHEMA}
 
@@ -256,15 +256,16 @@ def test_scope_args_explicit_overrides_take_precedence(harness: AgentHarness) ->
     meta = SkillMeta(name="saver", tool_schemas={"save_artifact": {"type": "object"}})
     skill = Skill(meta=meta, content="x", path=Path("x"))
     explicit = {"save_artifact": CONTENT_SCHEMA}
-    _allowed, overrides = harness._skill_tool_scope_args(skill, explicit)
+    _allowed, overrides, _bindings = harness._skill_tool_scope_args(skill, explicit)
     assert overrides["save_artifact"] is CONTENT_SCHEMA
 
 
 def test_scope_args_no_skill(harness: AgentHarness) -> None:
-    allowed, overrides = harness._skill_tool_scope_args(None, None)
+    allowed, overrides, bindings = harness._skill_tool_scope_args(None, None)
     assert allowed is None
     assert overrides is None
-    allowed, overrides = harness._skill_tool_scope_args(None, {"t": CONTENT_SCHEMA})
+    assert bindings is None
+    allowed, overrides, _bindings = harness._skill_tool_scope_args(None, {"t": CONTENT_SCHEMA})
     assert allowed is None
     assert overrides == {"t": CONTENT_SCHEMA}
 

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "agnoclaw"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "agno" },


### PR DESCRIPTION
Closes #54.

Adds a per-run kwarg `tool_arg_bindings={tool: {arg: value}}` on `run()`/`arun()` — a per-run analog of build-time partial application. For the duration of the run, for each named tool the bound args are **removed from the schema the model sees** AND **supplied at dispatch** (caller-wins; the model never sees or sets them), then restored on exit.

## Why a `functools.partial`, not a delete-from-schema hack
A naive "remove the property + inject in a hook" **produces an invalid schema**: Agno's `process_entrypoint` recomputes a tool's top-level `required` from the entrypoint signature every run, so a bound arg with no default is re-added to `required` while absent from `properties` — a dangling entry. The binding instead replaces the entrypoint with `partial(orig, **bound)`, advertises the stripped schema, and sets `skip_entrypoint_processing` so Agno keeps it verbatim (dispatch injection falls out for free). Validated through Agno's real deep-copy + dispatch path.

## Acceptance
- [x] Bound args absent from the model schema AND present in the dispatched call.
- [x] Restored after the run (success, exception, streaming); no leak across runs.
- [x] Composes with `allowed_tools` and `tool_schema_overrides`.
- [x] Example: `examples/tool_arg_bindings.py` — bind two args for one run; a second run sees the full signature.

## Notes
- `_ToolScope` now records/restores entrypoint + `skip_entrypoint_processing`.
- Skills may declare static bindings via `tool-arg-bindings` frontmatter; per-run values win.
- `_skill_tool_scope_args` now returns `(allowed, overrides, bindings)`.

## Tests
`tests/test_tool_arg_bindings.py` (11 new). Full CI suite: 798 passed, coverage 80.59% (gate 80%). Version 0.9.0 → 0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)